### PR TITLE
Redesigning the parameter record types and return record types

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ with others. OneDrive integrates with Microsoft Office so users can access Word,
 OneDrive. It doesn’t require a download and should already be a part of Windows 10. 
 
 <p align="center">
-<img src="./docs/images/One_Drive.png?raw=true" alt="One Drive"/>
+<img src="./docs/images/One_Drive.png?raw=true" alt="One Drive" width="500"/>
 </p>
 
 ## Key features of Microsoft OneDrive
@@ -80,15 +80,13 @@ account (currently logged in user).
     Before your app can get a token from the Microsoft identity platform, it must be registered in the Azure portal. 
     Registration integrates your app with the Microsoft identity platform and establishes the information that it 
     uses to get tokens
-    1. App Id
+    1. App ID
     2. Redirect URL
     3. App Secret <br/>
 
     **Step 1:** Register a new application in your Azure AD tenant.<br/>
     - In the App registrations page, click **New registration** and enter a meaningful name in the name field.
-    - In the **Supported account types** section, select Accounts in any organizational directory (Any Azure AD 
-    directory - Multi-tenant) and personal Microsoft accounts (e.g., Skype, Xbox, Outlook.com). Click Register to 
-    create the application.
+    - In the **Supported account types** section, select **Accounts in any organizational directory (Any Azure AD directory - Multi-tenant) and personal Microsoft accounts (e.g., Skype, Xbox, Outlook.com)** or **Personal Microsoft accounts only**. Click Register to create the application.
     - Provide a **Redirect URI** if necessary.
 
         ![Obtaining Credentials Step 1](docs/images/s1.png)
@@ -120,7 +118,7 @@ account (currently logged in user).
     - In a new browser, enter the below URL by replacing the <MS_CLIENT_ID> with the application ID.
 
         ```
-        https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=<MS_CLIENT_ID>&response_type=code&redirect_uri=https://oauth.pstmn.io/v1/browser-callback&response_mode=query&scope=openid offline_access https://graph.microsoft.com/Files.ReadWrite.All
+        https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=<MS_CLIENT_ID>&response_type=code&redirect_uri=https://oauth.pstmn.io/v1/browser-callback&response_mode=query&scope=openid offline_access <SPACE_SEPERATED_LIST_OF_SCOPES>
         ```
     
     - This will prompt you to enter the username and password for signing into the Azure Portal App.
@@ -140,7 +138,7 @@ account (currently logged in user).
         ```
         {
             "token_type": "Bearer",
-            "scope": "Files.ReadWrite openid User.Read Mail.Send Mail.ReadWrite",
+            "scope": "openid <LIST_OF_PERMISSIONS>",
             "expires_in": 3600,
             "ext_expires_in": 3600,
             "access_token": "<MS_ACCESS_TOKEN>",

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ballerina Connector For Microsoft OneDrive
 
 Connects to Microsoft OneDrive using Ballerina.
 
-- [Microsoft OneDrive Connector]
+- [Microsoft OneDrive Connector](#)
     - [Introduction](#introduction)
         - [What is Microsoft OneDrive](#what-is-microsoft-onedrive)
         - [Key features of Microsoft OneDrive](#key-features-of-microsoft-onedrive)
@@ -63,8 +63,8 @@ account (currently logged in user).
 - Microsoft Account
 - Access to Azure Portal
 - Java 11 installed - Java Development Kit (JDK) with version 11 is required
-- [Ballerina SL Alpha 5](https://ballerina.io/learn/user-guide/getting-started/setting-up-ballerina/installation-options/) installed 
-    - Ballerina Swan Lake Alpha 5 is required
+- [Ballerina SL Beta 1](https://ballerina.io/learn/user-guide/getting-started/setting-up-ballerina/installation-options/) installed 
+    - Ballerina Swan Lake Beta 1 is required
 
 ## Obtaining tokens
 - Create an account in OneDrive
@@ -169,7 +169,7 @@ scopes = [<MS_NECESSARY_SCOPES>]
 ## Supported Versions
 |                                                                                    | Version               |
 |------------------------------------------------------------------------------------|-----------------------|
-| Ballerina Language Version                                                         | **Swan Lake Beta 1** |
+| Ballerina Language Version                                                         | **Swan Lake Beta 1**  |
 | [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/overview) Version     | **v1.0**              |
 | Java Development Kit (JDK)                                                         | 11                    |
 
@@ -206,16 +206,15 @@ onedrive:Configuration configuration = {
         conflictResolutionBehaviour : "rename"
     };
 
-    onedrive:DriveItem|onedrive:Error driveItem = driveClient->createFolderById(parentID, item);
+    onedrive:DriveItemData|onedrive:Error driveItem = driveClient->createFolderById(parentID, item);
 
-    if (driveItem is onedrive:DriveItem) {
+    if (driveItem is onedrive:DriveItemData) {
         log:printInfo("Folder Created " + driveItem.toString());
         log:printInfo("Success!");
     } else {
         log:printError(driveItem.message());
     }
 ```
-
 ## Upload a file to OneDrive
 ### Step 1: Import OneDrive Package
 First, import the ballerinax/microsoft.onedrive module into the Ballerina project.
@@ -246,9 +245,9 @@ onedrive:Client driveClient = check new (config);
     string parentFolderPath = "<PARENT_FOLDER_PATH>";
     string mediaType = "image/png";
 
-    onedrive:DriveItem|onedrive:Error itemInfo = driveClient->uploadDriveItemToFolderByPath(parentFolderPath, 
+    onedrive:DriveItemData|onedrive:Error itemInfo = driveClient->uploadFileToFolderByPath(parentFolderPath, 
         fileNameNewForNewUploadByPath, byteArray, mediaType);
-    if (itemInfo is onedrive:DriveItem) {
+    if (itemInfo is onedrive:DriveItemData) {
         log:printInfo("Uploaded item " + itemInfo?.id.toString());
         log:printInfo("Success!");
     } else {
@@ -295,77 +294,79 @@ onedrive:Client driveClient = check new (config);
 ## Get DriveItem metadata
 Retrieve the metadata for a DriveItem in a Drive by item ID or file system path (relative path). 
 
-ID based addressing sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/get_item_metadata_by_id.bal
+- [ID based addressing sample](/onedrive/samples/get_item_metadata_by_id.bal)
 
-Path based addressing sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/get_item_metadata_by_path.bal 
+- [Path based addressing sample](/onedrive/samples/get_item_metadata_by_path.bal)
 
 Notes : <br/>
 This operation supports several OData query parameters as well as normal query parameters.
 * **$expand** 
 * **$select**
-* **includeDeletedItems=true** - Query parameter to return deleted items. This query parameter is only valid when targeting a driveItem by ID, and otherwise will be ignored.
+* **includeDeletedItems=true** - Query parameter to return deleted items. This query parameter is only valid when 
+targeting a driveItem by ID, and otherwise will be ignored.
 
-Sample with query parameters is available here: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/get_item_metadata_by_id_query_params.bal
+- [Sample with query parameters](/onedrive/samples/get_item_metadata_by_id_query_params.bal)
 
 ## Get recent DriveItems
 Lists a set of items that have been recently used by the `signed in user`. This will include items that are in the 
 user's drive as well as the items they have access to from other drives.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/get_recent_items.bal
+- [Sample](/onedrive/samples/get_recent_items.bal)
 
 ## Get DriveItems shared with me
 Retrieve a collection of `DriveItem` resources that have been shared with the `signed in user` of the OneDrive.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/get_shared_items.bal
+- [Sample](/onedrive/samples/get_shared_items.bal)
 
 ## Create new folders in OneDrive
 Create a new folder in a Drive with a specified parent item, referred with the parent folder's ID or file system path 
 (relative path).
 
-ID based addressing sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/create_folder_by_id.bal
+- [ID based addressing sample](/onedrive/samples/create_folder_by_id.bal)
 
-Path based addressing sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/create_folder_by_path.bal
+- [Path based addressing sample](/onedrive/samples/create_folder_by_path.bal)
 
 ## Update a DriveItem
 Update the metadata for a DriveItem in a Drive referring by item ID or file system path (relative path).
 
-ID based addressing sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/update_drive_item_by_id.bal
+- [ID based addressing sample](/onedrive/samples/update_drive_item_by_id.bal)
 
-Path based addressing sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/update_drive_item_by_path.bal
+- [Path based addressing sample](/onedrive/samples/update_drive_item_by_path.bal)
 
 **Notes:** <br/>
 * Item update does not work when item is open in browser (On editing view)
 https://stackoverflow.com/questions/50057662/not-able-to-update-file-stream-through-microsoft-graph-sdk-when-file-is-open-in
 
 * The set of exact fields which can be updated is not provided in the docs. 
-If we try to update facets which are not related to the current resource (eg: if the resource is a file and we send folder facet it gives an error) error occurs.
+If we try to update facets which are not related to the current resource (eg: if the resource is a file and we send 
+folder facet it gives an error) error occurs.
 
 ## Delete a DriveItem
 Delete a DriveItem in a Drive by using it's item ID or file system path (relative path).
 
-ID based addressing sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/delete_drive_item.by_id.bal
+- [ID based addressing sample](/onedrive/samples/delete_drive_item.by_id.bal)
 
-Path based addressing sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/delete_drive_item.by_path.bal
+- [Path based addressing sample](/onedrive/samples/delete_drive_item.by_path.bal)
 
 ## Restore DriveItem
 Restore a DriveItem that has been deleted and is currently in the recycle bin.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/restore_drive_item.bal
+- [Sample](/onedrive/samples/restore_drive_item.bal)
 
 ## Copy a DriveItem
 Asynchronously creates a copy of a DriveItem (including any children), under a new parent item or at the same location 
 with a new name.
 
-ID based addressing sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/copy_drive_item_by_id.bal
+- [ID based addressing sample](/onedrive/samples/copy_drive_item_by_id.bal)
 
-Path based addressing sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/copy_drive_item_by_path.bal
+- [Path based addressing sample](/onedrive/samples/copy_drive_item_by_path.bal)
 
 ## Download file
 Download the contents of the primary stream (file) of a DriveItem using item ID or it's file system path (relative path). 
 
-ID based addressing sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/download_file_by_id.bal
+- [ID based addressing sample](/onedrive/samples/download_file_by_id.bal)
 
-Path based addressing sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/download_file_by_path.bal
+- [Path based addressing sample](/onedrive/samples/download_file_by_path.bal)
 
 **Notes:** <br/> 
 * Only DriveItems with the file property can be downloaded.
@@ -373,9 +374,9 @@ Path based addressing sample is available at: https://github.com/ballerina-platf
 ## Upload a small file to a certain location in OneDrive
 Upload a new file to the Drive.
 
-ID based addressing sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/upload_file_to_parent_id.bal
+- [ID based addressing sample](/onedrive/samples/upload_file_to_parent_id.bal)
 
-Path based addressing sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/upload_file_to_parent_path.bal
+- [Path based addressing sample](/onedrive/samples/upload_file_to_parent_path.bal)
 
 **Notes:** <br/>
 * This method only supports files up to 4MB in size.
@@ -383,9 +384,9 @@ Path based addressing sample is available at: https://github.com/ballerina-platf
 ## Replace file
 Update the contents of an existing file in the Drive.
 
-ID based addressing sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/replace_file_using_id.bal
+- [ID based addressing sample](/onedrive/samples/replace_file_using_id.bal)
 
-Path based addressing sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/replace_file_using_path.bal
+- [Path based addressing sample](/onedrive/samples/replace_file_using_path.bal)
 
 **Notes:** <br/>
 * The file used for replacing must be of the same media type as the file which will be replaced.
@@ -394,7 +395,7 @@ Path based addressing sample is available at: https://github.com/ballerina-platf
 ## Upload a large file to a certain location in OneDrive
 Upload files up to the maximum file size. 
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/upload_large_file.bal
+- [Sample](/onedrive/samples/upload_large_file.bal)
 
 **Notes:** <br/> 
 * Maximum bytes in any given request should be less than 60 MiB.
@@ -405,7 +406,7 @@ Sample is available at: https://github.com/ballerina-platform/module-ballerinax-
 Search the hierarchy of items for items matching a query. You can search within a folder hierarchy, a whole drive, or 
 files shared with the current user.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/search_drive_items.bal
+- [Sample](/onedrive/samples/search_drive_items.bal)
 
 **Notes:** <br/>
 * Supports the **$expand**, **$select**, **$skipToken**, **$top**, and **$orderby** OData query parameters to customize 
@@ -417,22 +418,22 @@ the response.
 Create a new sharing link if the specified link type doesn't already exist for the calling application. If a sharing 
 link of the specified type already exists for the app, the existing sharing link will be returned.
 
-ID based addressing sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/get_sharable_link_from_id.bal
+- [ID based addressing sample](/onedrive/samples/get_sharable_link_from_id.bal)
 
-Path based addressing sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/get_sharable_link_from_path.bal
+- [Path based addressing sample](/onedrive/samples/get_sharable_link_from_path.bal)
 
 ## Get metadata for a shared DriveItem
 Access a shared DriveItem by using sharing URL.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/get_shared_drive_item.bal
+- [Sample](/onedrive/samples/get_shared_drive_item.bal)
 
 ## Send sharing invitation via emails
 Sends a sharing invitation for a DriveItem. A sharing invitation provides permissions to the recipients and optionally 
 sends them an email with a sharing link.
 
-ID based addressing sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/send_sharing_invitation_by_id.balal
+- [ID based addressing sample](/onedrive/samples/send_sharing_invitation_by_id.bal)
 
-Path based addressing sample is available at: https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive/tree/master/samples/send_sharing_invitation_by_path.bal
+- [Path based addressing sample](/onedrive/samples/send_sharing_invitation_by_path.bal)
 
 **Notes:** <br/>
 * OneDrive personal accounts cannot create or modify permissions on the root DriveItem.
@@ -449,10 +450,10 @@ Path based addressing sample is available at: https://github.com/ballerina-platf
         > **Note:** Set the JAVA_HOME environment variable to the path name of the directory into which you installed 
         JDK.
 
-2. Download and install [Ballerina SLP8](https://ballerina.io/). 
+2. Download and install [Ballerina SLBeta 1](https://ballerina.io/). 
 
 ## Building the Source
-Execute the commands below to build from the source after installing Ballerina SL Alpha 5 version.
+Execute the commands below to build from the source after installing Ballerina SL Beta 1 version.
 
 1. To build the library:
 ```shell script

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 group=org.ballerinalang.microsoft.onedrive
-version=1.0.1-SNAPSHOT
+version=1.0.1
 ballerinaLangVersion=2.0.0-beta.1

--- a/onedrive/Ballerina.toml
+++ b/onedrive/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org= "ballerinax"
 name= "microsoft.onedrive"
-version= "1.0.1-SNAPSHOT"
+version= "1.0.1"
 authors = ["Ballerina"]
 keywords = ["Microsoft", "OneDrive", "drive"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-microsoft.onedrive"

--- a/onedrive/Package.md
+++ b/onedrive/Package.md
@@ -8,7 +8,7 @@ service resources. This version of the connector only supports the access to the
 account (currently logged in user).
 
 ## Compatibility
-Ballerina Language Version&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**Swan Lake Alpha 5**<br/>
+Ballerina Language Version&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**Swan Lake Beta 1**<br/>
 [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/overview) Version&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **v1.0**<br/>
 Java Development Kit (JDK)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;11                    
 

--- a/onedrive/client_endpoint.bal
+++ b/onedrive/client_endpoint.bal
@@ -264,7 +264,7 @@ public client class Client {
     # + return - A `string` which represents the ID of the newly created copy if sucess. Else `Error`.
     @display {label: "Copy drive item (Path based)"}
     remote isolated function copyDriveItemInPath(@display {label: "Item Path Relative to Drive Root"} string itemPath, 
-                                                 @display {label: "New name for the copy"} string? name = (), 
+                                                 @display {label: "New Name For Copy"} string? name = (), 
                                                  @display {label: "Parent Item Data"} 
                                                  ParentReference? parentReference = ()) 
                                                  returns @tainted @display {label: "Item ID"} string|Error {
@@ -280,7 +280,7 @@ public client class Client {
     # + return - A record of type `File`
     @display {label: "Download file (ID based)"}
     remote isolated function downloadFileById(@display {label: "Item ID"} string itemId, 
-                                              @display {label: "Item format data"} FileFormat? formatToConvert = ()) 
+                                              @display {label: "Item Format Data"} FileFormat? formatToConvert = ()) 
                                               returns @tainted File|Error {
         string path = EMPTY_STRING;
         if (formatToConvert is ()) {
@@ -302,7 +302,7 @@ public client class Client {
     # + return - A record of type `File` if successful. Else `Error`.
     @display {label: "Download file (Path based)"}
     remote isolated function downloadFileByPath(@display {label: "Item Path Relative to Drive Root"} string itemPath, 
-                                                @display {label: "Item format data"} FileFormat? formatToConvert = ()) 
+                                                @display {label: "Item Format Data"} FileFormat? formatToConvert = ()) 
                                                 returns @tainted File|Error {
         string path = EMPTY_STRING;
         if (formatToConvert is ()) {
@@ -323,8 +323,8 @@ public client class Client {
     #                          file.
     # + return - A record of type `File` if successful. Else `Error`.
     @display {label: "Download file by download URL"}
-    remote isolated function downloadFileByDownloadUrl(@display {label: "Downloadable url of file"} string downloadUrl, 
-                                                       @display {label: "Byte range for partial content"} 
+    remote isolated function downloadFileByDownloadUrl(@display {label: "Downloadable URL of File"} string downloadUrl, 
+                                                       @display {label: "Byte Range for Partial Content"} 
                                                        ByteRange? partialContentOption = ()) returns 
                                                        @tainted File|Error {
         map<string> headerMap = {};
@@ -430,7 +430,7 @@ public client class Client {
     @display {label: "Upload file (ID based)"}
     remote isolated function uploadFileToFolderById(@display {label: "Parent Folder ID"} string parentFolderId, 
                                                     @display {label: "File Name"} string fileName, 
-                                                    @display {label: "Array of bytes"} byte[] byteArray, 
+                                                    @display {label: "Array of Bytes"} byte[] byteArray, 
                                                     @display {label: "Mime Type"} string mimeType) returns 
                                                     @tainted DriveItemData|Error {
         string path = check createPathBasedUrl([LOGGED_IN_USER, DRIVE_RESOURCE, ALL_DRIVE_ITEMS, parentFolderId], 
@@ -451,7 +451,7 @@ public client class Client {
     @display {label: "Upload file (Path based)"}
     remote isolated function uploadFileToFolderByPath(@display {label: "Parent Folder Path"} string parentFolderPath, 
                                                       @display {label: "File Name"} string fileName, 
-                                                      @display {label: "Array of bytes"} byte[] byteArray, 
+                                                      @display {label: "Array of Bytes"} byte[] byteArray, 
                                                       @display {label: "Mime Type"} string mimeType) returns 
                                                       @tainted DriveItemData|Error {
         string path = check createPathBasedUrl([LOGGED_IN_USER, DRIVE_RESOURCE, DRIVE_ROOT], 
@@ -468,7 +468,7 @@ public client class Client {
     # + return - A record of type `DriveItemData` if sucess. Else `Error`.
     @display {label: "Replace file (ID based)"}
     remote isolated function replaceFileUsingId(@display {label: "Item ID"} string itemId, 
-                                                @display {label: "Array of bytes"} byte[] byteArray, 
+                                                @display {label: "Array of Bytes"} byte[] byteArray, 
                                                 @display {label: "Mime Type"} string mimeType) returns 
                                                 @tainted DriveItemData|Error {
         string path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, ALL_DRIVE_ITEMS, itemId, 
@@ -486,7 +486,7 @@ public client class Client {
     # + return - A record of type `DriveItemData` if sucess. Else `Error`.
     @display {label: "Replace file (Path based)"}
     remote isolated function replaceFileUsingPath(@display {label: "Item Path Relative to Drive Root"} string itemPath,                                                    
-                                                  @display {label: "Array of bytes"} byte[] byteArray, 
+                                                  @display {label: "Array of Bytes"} byte[] byteArray, 
                                                   @display {label: "Mime Type"} string mimeType) returns 
                                                   @tainted DriveItemData|Error {
         string path = check createPathBasedUrl([LOGGED_IN_USER, DRIVE_RESOURCE, DRIVE_ROOT], itemPath, 
@@ -509,7 +509,7 @@ public client class Client {
     @display {label: "Upload a large file"}
     remote function resumableUploadDriveItem(@display {label: "Item Path Relative to Drive Root"} string itemPath, 
                                              @display {label: "Information About File"} UploadMetadata itemInfo, 
-                                             @display {label: "Stream of bytes"} 
+                                             @display {label: "Stream of Bytes"} 
                                              stream<io:Block,io:Error?> binaryStream) returns 
                                              @tainted DriveItemData|Error { 
         string path = check createPathBasedUrl([DRIVE_RESOURCE, DRIVE_ROOT], itemPath, [CREATE_UPLOAD_SESSION_ACTION]);
@@ -583,7 +583,7 @@ public client class Client {
     # + return - A record of type `Permission` if sucess. Else `Error`.
     @display {label: "Get sharable links (ID based)"}
     remote isolated function getSharableLinkFromId(@display {label: "Item ID"} string itemId, 
-                                                   @display {label: "Permission options"} PermissionOptions options) 
+                                                   @display {label: "Permission Options"} PermissionOptions options) 
                                                    returns @tainted @display {label: "Permission Information"} 
                                                    Permission|Error {
         string path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, ALL_DRIVE_ITEMS, itemId, 
@@ -603,7 +603,7 @@ public client class Client {
     @display {label: "Get sharable links (Path based)"}
     remote isolated function getSharableLinkFromPath(@display {label: "Item Path Relative to Drive Root"} 
                                                      string itemPath, 
-                                                     @display {label: "Permission options"} PermissionOptions options)
+                                                     @display {label: "Permission Options"} PermissionOptions options)
                                                      returns @tainted Permission|Error {
         string path = check createPathBasedUrl([LOGGED_IN_USER, DRIVE_RESOURCE, DRIVE_ROOT], itemPath, 
             [CREATE_LINK_ACTION]);
@@ -652,8 +652,7 @@ public client class Client {
     # + return - A record of type `Permission` if sucess. Else `Error`.
     @display {label: "Send Sharing Invitation (Path based)"}
     remote isolated function sendSharingInvitationByPath(@display {label: "Item Path Relative to Drive Root"} 
-                                                         string itemPath, 
-                                                         @display {label: "Sharing Invitation"} 
+                                                         string itemPath, @display {label: "Sharing Invitation"} 
                                                          ItemShareInvitation invitation) returns 
                                                          @tainted Permission|Error {
         string path = check createPathBasedUrl([LOGGED_IN_USER, DRIVE_RESOURCE, DRIVE_ROOT], itemPath, [INVITE_ACTION]);

--- a/onedrive/client_endpoint.bal
+++ b/onedrive/client_endpoint.bal
@@ -47,23 +47,23 @@ public client class Client {
     # Lists a set of items that have been recently used by the `signed in user`. This will include items that are in the
     # user's drive as well as the items they have access to from other drives.
     # 
-    # + return - An array of type `DriveItem` if sucess. Else `Error`.
+    # + return - An array of type `DriveItemData` if sucess. Else `Error`.
     @display {label: "Get list of recent items"}
-    remote isolated function getRecentItems() returns @tainted @display {label: "DriveItem List"} DriveItem[]|Error {
+    remote isolated function getRecentItems() returns @tainted @display {label: "DriveItem List"} DriveItemData[]|Error {
         string path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, RECENT_ITEMS]);
         return check getDriveItemArray(self.httpClient, path);
     }
 
-    # Retrieve a collection of `DriveItem` resources that have been shared with the `signed in user` of the OneDrive.
+    # Retrieve a collection of `DriveItemData` resources that have been shared with the `signed in user` of the OneDrive.
     # 
     # + queryParams - An array of type `string` in the format `<QUERY_PARAMETER_NAME>=<PARAMETER_VALUE>`
     #                 (By default, sharedWithMe return items shared within your own tenant. To include items shared from
     #                  external tenants, append `allowexternal=true` query parameter)
-    # + return - An array of type `DriveItem` if sucess. Else `Error`.
+    # + return - An array of type `DriveItemData` if sucess. Else `Error`.
     @display {label: "Get list of items shared with me"}
     remote isolated function getItemsSharedWithMe(@display {label: "Optional Query Parameters"} 
                                                   string[] queryParams = []) returns 
-                                                  @tainted @display {label: "DriveItem List"} DriveItem[]|error {
+                                                  @tainted @display {label: "DriveItem List"} DriveItemData[]|error {
         string path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, SHARED_WITH_LOGGED_IN_USER], 
             queryParams);
         return check getDriveItemArray(self.httpClient, path);
@@ -76,11 +76,11 @@ public client class Client {
     # 
     # + parentFolderId - The folder ID of the parent folder where, the new folder will be created.
     # + folderMetadata - A record of type `FolderMetadata` which contains the necessary data to create a folder
-    # + return - A record of type `DriveItem` if sucess. Else `Error`.
+    # + return - A record of type `DriveItemData` if sucess. Else `Error`.
     @display {label: "Create new folder (ID based)"}
-    remote isolated function createFolderById(@display {label: "Parent Folder Id"} string parentFolderId, 
+    remote isolated function createFolderById(@display {label: "Parent Folder ID"} string parentFolderId, 
                                               @display {label: "Additional Folder Data"} FolderMetadata folderMetadata) 
-                                              returns @tainted DriveItem|Error { 
+                                              returns @tainted DriveItemData|Error { 
         string path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, ALL_DRIVE_ITEMS, parentFolderId, 
             CHILDREN_RESOURCES]);
         return check createFolder(self.httpClient, path, folderMetadata);
@@ -93,11 +93,11 @@ public client class Client {
     #                      **NOTE:** When you want to create a folder on root itself, you must give the relative path of 
     #                      the new folder only.
     # + folderMetadata - A record of type `FolderMetadata` which contains the necessary data to create a folder
-    # + return - A record of type `DriveItem` if sucess. Else `Error`.
+    # + return - A record of type `DriveItemData` if sucess. Else `Error`.
     @display {label: "Create new folder (Path based)"}
     remote isolated function createFolderByPath(@display {label: "Parent Folder Path"} string parentFolderPath, 
                                                 @display {label: "Additional Folder Data"} FolderMetadata folderMetadata) 
-                                                returns @tainted DriveItem|Error {
+                                                returns @tainted DriveItemData|Error {
         string path = EMPTY_STRING;
         if (parentFolderPath == EMPTY_STRING || parentFolderPath == FORWARD_SLASH) {
             path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, DRIVE_ROOT, CHILDREN_RESOURCES]);
@@ -105,7 +105,7 @@ public client class Client {
             path = check createPathBasedUrl([LOGGED_IN_USER, DRIVE_RESOURCE, DRIVE_ROOT], parentFolderPath, 
                 [CHILDREN_RESOURCES]);
         }
-        return check createFolder(self.httpClient, <@untainted>path, folderMetadata);
+        return check createFolder(self.httpClient, path, folderMetadata);
     }
 
     # Retrieve the metadata for a DriveItem in a Drive by item ID.
@@ -115,13 +115,13 @@ public client class Client {
     #                 It should be an array of type `string` in the format `<QUERY_PARAMETER_NAME>=<PARAMETER_VALUE>`
     #                 **Note:** For more information about query parameters, refer here: 
     #                   https://docs.microsoft.com/en-us/graph/query-parameters
-    # + return - A record of type `DriveItem` if sucess. Else `Error`.
+    # + return - A record of type `DriveItemData` if sucess. Else `Error`.
     @display {label: "Get item metadata (ID based)"}
-    remote isolated function getItemMetadataById(@display {label: "Item Id"} string itemId, 
+    remote isolated function getItemMetadataById(@display {label: "Item ID"} string itemId, 
                                                  @display {label: "Optional Query Parameters"} 
-                                                 string[] queryParams = []) returns @tainted DriveItem|Error {
+                                                 string[] queryParams = []) returns @tainted DriveItemData|Error {
         string path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, ALL_DRIVE_ITEMS, itemId], queryParams);
-        return check getDriveItem(self.httpClient, <@untainted>path);
+        return check getDriveItem(self.httpClient, path);
     }
 
     # Retrieve the metadata for a DriveItem in a Drive by file system path.
@@ -132,13 +132,13 @@ public client class Client {
     #                 It should be an array of type `string` in the format `<QUERY_PARAMETER_NAME>=<PARAMETER_VALUE>`
     #                 **Note:** For more information about query parameters, refer here: 
     #                   https://docs.microsoft.com/en-us/graph/query-parameters
-    # + return - A record of type `DriveItem` if sucess. Else `Error`.
+    # + return - A record of type `DriveItemData` if sucess. Else `Error`.
     @display {label: "Get item metadata (Path based)"}
     remote isolated function getItemMetadataByPath(@display {label: "Item Path Relative to Drive Root"} string itemPath, 
                                                    @display {label: "Optional Query Parameters"} 
-                                                   string[] queryParams = []) returns @tainted DriveItem|Error {
+                                                   string[] queryParams = []) returns @tainted DriveItemData|Error {
         string path = check createPathBasedUrl([LOGGED_IN_USER, DRIVE_RESOURCE, DRIVE_ROOT], itemPath, [], queryParams);
-        return check getDriveItem(self.httpClient, <@untainted>path);
+        return check getDriveItem(self.httpClient, path);
     }
 
     # Update the metadata for a DriveItem in a Drive referring by item ID.
@@ -147,11 +147,11 @@ public client class Client {
     # + replacementData - A record of type `DriveItem` which contains the values for properties that should be updated
     # + return - A record of type `DriveItem` if sucess. Else `Error`.
     @display {label: "Update item metadata (ID based)"}
-    remote isolated function updateDriveItemById(@display {label: "Item Id"} string itemId, 
-                                                 @display {label: "Replacement Item Data"} DriveItem replacementData) 
-                                                 returns @tainted DriveItem|Error {
+    remote isolated function updateDriveItemById(@display {label: "Item ID"} string itemId, 
+                                                 @display {label: "Replacement Item Data"} DriveItem replacementData)
+                                                 returns @tainted DriveItemData|Error {
         string path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, ALL_DRIVE_ITEMS, itemId]);
-        return updateDriveItem(self.httpClient, <@untainted>path, replacementData); 
+        return updateDriveItem(self.httpClient, path, replacementData); 
     }
 
     # Update the metadata for a DriveItem in a Drive by file system path.
@@ -162,10 +162,10 @@ public client class Client {
     # + return - A record of type `DriveItem` if sucess. Else `Error`.
     @display {label: "Update item metadata (Path based)"}
     remote isolated function updateDriveItemByPath(@display {label: "Item Path Relative to Drive Root"} string itemPath, 
-                                                   @display {label: "Replacement Item Data"} DriveItem replacementData) 
-                                                   returns @tainted DriveItem|Error {
+                                                   @display {label: "Replacement Item Data"} DriveItem replacementData)
+                                                   returns @tainted DriveItemData|Error {
         string path = check createPathBasedUrl([LOGGED_IN_USER, DRIVE_RESOURCE, DRIVE_ROOT], itemPath);
-        return updateDriveItem(self.httpClient, <@untainted>path, replacementData); 
+        return updateDriveItem(self.httpClient, path, replacementData); 
     }
 
     # Delete a DriveItem in a Drive by using it's ID.
@@ -173,9 +173,9 @@ public client class Client {
     # + itemId - The ID of the DriveItem
     # + return - Returns `nil` is success. Else `Error`.
     @display {label: "Delete drive item (ID based)"}
-    remote isolated function deleteDriveItemById(@display {label: "Item Id"} string itemId) returns @tainted Error? {
+    remote isolated function deleteDriveItemById(@display {label: "Item ID"} string itemId) returns @tainted Error? {
         string path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, ALL_DRIVE_ITEMS, itemId]);
-        http:Response response = check self.httpClient->delete(<@untainted>path);
+        http:Response response = check self.httpClient->delete(path);
         _ = check handleResponse(response);
     }
 
@@ -188,7 +188,7 @@ public client class Client {
     remote isolated function deleteDriveItemByPath(@display {label: "Item Path Relative to Drive Root"} string itemPath) 
                                                    returns @tainted Error? {
         string path = check createPathBasedUrl([LOGGED_IN_USER, DRIVE_RESOURCE, DRIVE_ROOT], itemPath);
-        http:Response response = check self.httpClient->delete(<@untainted>path);
+        http:Response response = check self.httpClient->delete(path);
         _ = check handleResponse(response);
     }
 
@@ -196,34 +196,37 @@ public client class Client {
     # currently only available for OneDrive Personal.
     # 
     # + itemId - The ID of the DriveItem
-    # + parentReference - Optional. A record of type `ItemReference` that represents reference to the parent item the 
-    #                     deleted item will be restored to.
-    # + name - Optional. The new name for the restored item. If this isn't provided, the same name will be used as 
+    # + parentFolderId - The ID of the parent item the deleted item will be restored to
+    # + name - The new name for the restored item. If this isn't provided, the same name will be used as 
     #          the original.
-    # + return - A record of type `DriveItem` if sucess. Else `Error`.
+    # + return - A record of type `DriveItemData` if sucess. Else `Error`.
     @display {label: "Restore drive item"}
-    remote isolated function restoreDriveItem(@display {label: "Item Id"} string itemId, 
-                                              @display {label: "Parent Item Data"} ItemReference? parentReference = (), 
+    remote isolated function restoreDriveItem(@display {label: "Item ID"} string itemId, 
+                                              @display {label: "Parent Folder ID"} string? parentFolderId = (),
                                               @display {label: "New File Name"} string? name = ())
-                                              returns @tainted DriveItem|Error {
+                                              returns @tainted DriveItemData|Error {
         string path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, ALL_DRIVE_ITEMS, itemId, 
             RESTORE_ACTION]);
         json restoreItemOptions = {};
-        if (name is () && parentReference != ()) {
+        if (name is () && parentFolderId != ()) {
             restoreItemOptions = {
-                                    parentReference : check parentReference.cloneWithType(json)
+                                    parentReference : {
+                                        id: parentFolderId
+                                    }
                                  };
-        } else if (name != () && parentReference != ()) {
+        } else if (name != () && parentFolderId != ()) {
             restoreItemOptions = {
-                                    parentReference : check parentReference.cloneWithType(json),
-                                    name: name
-                                 };
-        } else if (name != () && parentReference is ()) {
+                                    name: name,
+                                    parentReference : {
+                                        id: parentFolderId
+                                    }
+                                };
+        } else if (name != () && parentFolderId is ()) {
             restoreItemOptions = {
                                     name: name
                                  };
         }
-        http:Response response = check self.httpClient->post(<@untainted>path, restoreItemOptions);
+        http:Response response = check self.httpClient->post(path, restoreItemOptions);
         map<json>|string? handledResponse = check handleResponse(response);
         if (handledResponse is map<json>) {
             return check convertToDriveItem(handledResponse);
@@ -236,18 +239,18 @@ public client class Client {
     # location with a new name.
     # 
     # + itemId - The ID of the DriveItem
-    # + name - Optional. The new name for the copy. If this isn't provided, the same name will be used as the original.
-    # + parentReference - Optional. A record of type `ItemReference` that represents reference to the parent item the 
+    # + name - The new name for the copy. If this isn't provided, the same name will be used as the original.
+    # + parentReference - A record of type `ParentReference` that represents reference to the parent item the 
     #                     copy will be created in.
     # + return - A `string` which represents the ID of the newly created copy if sucess. Else `Error`.
     @display {label: "Copy drive item (ID based)"}
-    remote isolated function copyDriveItemWithId(@display {label: "Item Id"} string itemId, 
+    remote isolated function copyDriveItemWithId(@display {label: "Item ID"} string itemId, 
                                                  @display {label: "New File Name"} string? name = (), 
                                                  @display {label: "Parent Item Data"} 
-                                                 ItemReference? parentReference = ()) 
-                                                 returns @tainted @display {label: "Item Id"} string|Error {
+                                                 ParentReference? parentReference = ()) 
+                                                 returns @tainted @display {label: "Item ID"} string|Error {
         string path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, ALL_DRIVE_ITEMS, itemId, COPY_ACTION]);
-        return check copyDriveItem(self.httpClient, <@untainted>path, parentReference, name);
+        return check copyDriveItem(self.httpClient, path, parentReference, name);
     }
 
     # Asynchronously creates a copy of a DriveItem (including any children), under a new parent item or at the same 
@@ -255,28 +258,28 @@ public client class Client {
     # 
     # + itemPath - The file system path of the DriveItem. The hierarchy of the path allowed in this function is relative
     #              to the `root` of the respective Drive. So, the relative path from `root` must be provided.
-    # + name - Optional. The new name for the copy. If this isn't provided, the same name will be used as the original.
-    # + parentReference - Optional. A record of type `ItemReference` that represents reference to the parent item the 
+    # + name - The new name for the copy. If this isn't provided, the same name will be used as the original.
+    # + parentReference - A record of type `ParentReference` that represents reference to the parent item the 
     #                     copy will be created in.
     # + return - A `string` which represents the ID of the newly created copy if sucess. Else `Error`.
     @display {label: "Copy drive item (Path based)"}
     remote isolated function copyDriveItemInPath(@display {label: "Item Path Relative to Drive Root"} string itemPath, 
                                                  @display {label: "New name for the copy"} string? name = (), 
                                                  @display {label: "Parent Item Data"} 
-                                                 ItemReference? parentReference = ()) 
-                                                 returns @tainted @display {label: "Item Id"} string|Error {
+                                                 ParentReference? parentReference = ()) 
+                                                 returns @tainted @display {label: "Item ID"} string|Error {
         string path = check createPathBasedUrl([LOGGED_IN_USER, DRIVE_RESOURCE, DRIVE_ROOT], itemPath, [COPY_ACTION]);
-        return check copyDriveItem(self.httpClient, <@untainted>path, parentReference, name);
+        return check copyDriveItem(self.httpClient, path, parentReference, name);
     }
 
     # Download the contents of the primary stream (file) of a DriveItem using item ID. **NOTE:** Only driveItems with 
     # the file property can be downloaded.
     # 
     # + itemId - The ID of the DriveItem
-    # + formatToConvert - Optional. Specify the format the item's content should be downloaded as.
+    # + formatToConvert - Specify the format the item's content should be downloaded as.
     # + return - A record of type `File`
     @display {label: "Download file (ID based)"}
-    remote isolated function downloadFileById(@display {label: "Item Id"} string itemId, 
+    remote isolated function downloadFileById(@display {label: "Item ID"} string itemId, 
                                               @display {label: "Item format data"} FileFormat? formatToConvert = ()) 
                                               returns @tainted File|Error {
         string path = EMPTY_STRING;
@@ -287,7 +290,7 @@ public client class Client {
             path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, ALL_DRIVE_ITEMS, itemId, 
                 CONTENT_OF_DRIVE_ITEM], [string `format=${formatToConvert.toString()}`]);
         }
-        return check downloadDriveItem(self.httpClient, <@untainted>path);
+        return check downloadDriveItem(self.httpClient, path);
     }
 
     # Download the contents of the primary stream (file) of a DriveItem using item path. **NOTE:** Only driveItems 
@@ -295,13 +298,12 @@ public client class Client {
     # 
     # + itemPath - The file system path of the File. The hierarchy of the path allowed in this function is relative
     #              to the `root` of the respective Drive. So, the relative path from `root` must be provided.
-    # + formatToConvert - Optional. Specify the format the item's content should be downloaded as.
+    # + formatToConvert - Specify the format the item's content should be downloaded as.
     # + return - A record of type `File` if successful. Else `Error`.
     @display {label: "Download file (Path based)"}
     remote isolated function downloadFileByPath(@display {label: "Item Path Relative to Drive Root"} string itemPath, 
                                                 @display {label: "Item format data"} FileFormat? formatToConvert = ()) 
-                                                returns 
-                                                @tainted File|Error {
+                                                returns @tainted File|Error {
         string path = EMPTY_STRING;
         if (formatToConvert is ()) {
             path = check createPathBasedUrl([LOGGED_IN_USER, DRIVE_RESOURCE, DRIVE_ROOT], itemPath, 
@@ -310,14 +312,14 @@ public client class Client {
             path = check createPathBasedUrl([LOGGED_IN_USER, DRIVE_RESOURCE, DRIVE_ROOT], itemPath, 
                 [CONTENT_OF_DRIVE_ITEM], [string `format=${formatToConvert.toString()}`]);
         }
-        return check downloadDriveItem(self.httpClient, <@untainted>path);
+        return check downloadDriveItem(self.httpClient, path);
     }
 
     # Download the contents of the primary stream (file) of a DriveItem using download URL. **NOTE:** Only driveItems 
     # with the file property can be downloaded.
     # 
     # + downloadUrl - Download URL for a specific DriveItem
-    # + partialContentOption - Optional. The value for the `Range` header to download a partial range of bytes from the 
+    # + partialContentOption - The value for the `Range` header to download a partial range of bytes from the 
     #                          file.
     # + return - A record of type `File` if successful. Else `Error`.
     @display {label: "Download file by download URL"}
@@ -342,18 +344,18 @@ public client class Client {
     // # + parentFolderId - The folder ID of the parent folder where, the new file will be uploaded
     // # + fileName - The name of the new file
     // # + binaryStream - An stream of `byte[]` that represents a binary stream of the file to be uploaded
-    // # + mediaType - The media type of the uploading file
-    // # + return - A record of type `DriveItem` if success. Else `Error`.
+    // # + mimeType - The media type of the uploading file
+    // # + return - A record of type `DriveItemData` if success. Else `Error`.
     // @display {label: "Upload file (ID based)"}
-    // remote isolated function uploadFileToFolderById(@display {label: "Parent Folder Id"} string parentFolderId, 
+    // remote isolated function uploadFileToFolderById(@display {label: "Parent Folder ID"} string parentFolderId, 
     //                                                 @display {label: "File Name"} string fileName, 
     //                                                 @display {label: "Stream of bytes to upload"} 
     //                                                 stream<byte[],io:Error?> binaryStream, 
-    //                                                 @display {label: "Media Type"} string mediaType) returns 
-    //                                                 @tainted @display {label: "DriveItem Metadata"} DriveItem|Error {
+    //                                                 @display {label: "Mime Type"} string mimeType) returns 
+    //                                                 @tainted @display {label: "DriveItem Metadata"} DriveItemData|Error {
     //     string path = check createPathBasedUrl([LOGGED_IN_USER, DRIVE_RESOURCE, ALL_DRIVE_ITEMS, parentFolderId], 
     //         string `/${fileName}`, [CONTENT_OF_DRIVE_ITEM]);
-    //     return uploadDriveItem(self.httpClient, <@untainted>path, binaryStream, mediaType); 
+    //     return uploadDriveItem(self.httpClient, path, binaryStream, mimeType); 
     // }
 
     // # Upload a new file to the Drive. This method only supports files up to 4MB in size.
@@ -364,19 +366,19 @@ public client class Client {
     // #                      of the new folder only.
     // # + fileName - The name of the new file
     // # + binaryStream - An stream of `byte[]` that represents a binary stream of the file to be uploaded
-    // # + mediaType - The media type of the uploading file
-    // # + return - A record of type `DriveItem` if success. Else `Error`.
+    // # + mimeType - The media type of the uploading file
+    // # + return - A record of type `DriveItemData` if success. Else `Error`.
     // @display {label: "Upload file (Path based)"}
     // remote isolated function uploadFileToFolderByPath(@display {label: "Parent Folder Path"} 
     //                                                   string parentFolderPath, 
     //                                                   @display {label: "File Name"} string fileName, 
     //                                                   @display {label: "Stream of bytes to upload"} 
     //                                                   stream<byte[],io:Error?> binaryStream, 
-    //                                                   @display {label: "Media Type"} string mediaType) returns 
-    //                                                   @tainted @display {label: "DriveItem Metadata"} DriveItem|Error {
+    //                                                   @display {label: "Mime Type"} string mimeType) returns 
+    //                                                   @tainted @display {label: "DriveItem Metadata"} DriveItemData|Error {
     //     string path = check createPathBasedUrl([LOGGED_IN_USER, DRIVE_RESOURCE, DRIVE_ROOT], 
     //         string `${parentFolderPath}/${fileName}`, [CONTENT_OF_DRIVE_ITEM]);
-    //     return uploadDriveItem(self.httpClient, <@untainted>path, binaryStream, mediaType); 
+    //     return uploadDriveItem(self.httpClient, path, binaryStream, mimeType); 
     // }
     
     // # Update the contents of an existing file in the Drive. This method only supports files up to 4MB in size.
@@ -384,17 +386,17 @@ public client class Client {
     // # 
     // # + itemId - The ID of the DriveItem
     // # + binaryStream - An stream of `byte[]` that represents a binary stream of the file to be uploaded
-    // # + mediaType - The media type of the uploading file
-    // # + return - A record of type `DriveItem` if success. Else `Error`.
+    // # + mimeType - The media type of the uploading file
+    // # + return - A record of type `DriveItemData` if success. Else `Error`.
     // @display {label: "Replace file (ID based)"}
-    // remote isolated function replaceFileUsingId(@display {label: "Item Id"} string itemId,
+    // remote isolated function replaceFileUsingId(@display {label: "Item ID"} string itemId,
     //                                             @display {label: "Stream of bytes to upload"}  
     //                                             stream<byte[],io:Error?> binaryStream, 
-    //                                             @display {label: "Media Type"} string mediaType) returns 
-    //                                             @tainted @display {label: "DriveItem Metadata"} DriveItem|Error {
+    //                                             @display {label: "Mime Type"} string mimeType) returns 
+    //                                             @tainted @display {label: "DriveItem Metadata"} DriveItemData|Error {
     //     string path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, ALL_DRIVE_ITEMS, itemId, 
     //         CONTENT_OF_DRIVE_ITEM]);
-    //     return uploadDriveItem(self.httpClient, <@untainted>path, binaryStream, mediaType); 
+    //     return uploadDriveItem(self.httpClient, path, binaryStream, mimeType); 
     // }
 
     // # Update the contents of an existing file in the Drive. This method only supports files up to 4MB in size.
@@ -403,20 +405,19 @@ public client class Client {
     // # + itemPath - The file system path of the File. The hierarchy of the path allowed in this function is relative
     // #              to the `root` of the respective Drive. So, the relative path from `root` must be provided.
     // # + binaryStream - An stream of `byte[]` that represents a binary stream of the file to be uploaded
-    // # + mediaType - The media type of the uploading file
-    // # + return - A record of type `DriveItem` if success. Else `Error`.
+    // # + mimeType - The media type of the uploading file
+    // # + return - A record of type `DriveItemData` if success. Else `Error`.
     // @display {label: "Replace file (Path based)"}
     // remote isolated function replaceFileUsingPath(@display {label: "Item Path Relative to Drive Root"} string itemPath, 
     //                                               @display {label: "Stream of bytes to upload"}  
     //                                               stream<byte[],io:Error?> binaryStream, 
-    //                                               @display {label: "Media Type"} string mediaType) returns 
-    //                                               @tainted @display {label: "DriveItem Metadata"} DriveItem|Error {
+    //                                               @display {label: "Mime Type"} string mimeType) returns 
+    //                                               @tainted @display {label: "DriveItem Metadata"} DriveItemData|Error {
     //     string path = check createPathBasedUrl([LOGGED_IN_USER, DRIVE_RESOURCE, DRIVE_ROOT], itemPath, 
     //         [CONTENT_OF_DRIVE_ITEM]);
-    //     return uploadDriveItem(self.httpClient, <@untainted>path, binaryStream, mediaType); 
+    //     return uploadDriveItem(self.httpClient, path, binaryStream, mimeType); 
     // }
     //******************************************************************************************************************
-
 
     //************************ Functions for uploading and replacing the files using byte[] ****************************
     # Upload a new file to the Drive. This method only supports files up to 4MB in size.
@@ -424,17 +425,17 @@ public client class Client {
     # + parentFolderId - The folder ID of the parent folder where, the new file will be uploaded
     # + fileName - The name of the new file
     # + byteArray - An array of `byte` that represents a binary form of the file to be uploaded
-    # + mediaType - The media type of the uploading file
-    # + return - A record of type `DriveItem` if sucess. Else `Error`.
+    # + mimeType - The mime type of the uploading file
+    # + return - A record of type `DriveItemData` if sucess. Else `Error`.
     @display {label: "Upload file (ID based)"}
-    remote isolated function uploadFileToFolderById(@display {label: "Parent Folder Id"} string parentFolderId, 
+    remote isolated function uploadFileToFolderById(@display {label: "Parent Folder ID"} string parentFolderId, 
                                                     @display {label: "File Name"} string fileName, 
                                                     @display {label: "Array of bytes"} byte[] byteArray, 
-                                                    @display {label: "Media Type"} string mediaType) returns 
-                                                    @tainted DriveItem|Error {
+                                                    @display {label: "Mime Type"} string mimeType) returns 
+                                                    @tainted DriveItemData|Error {
         string path = check createPathBasedUrl([LOGGED_IN_USER, DRIVE_RESOURCE, ALL_DRIVE_ITEMS, parentFolderId], 
             string `/${fileName}`, [CONTENT_OF_DRIVE_ITEM]);
-        return uploadDriveItemByteArray(self.httpClient, <@untainted>path, byteArray, mediaType); 
+        return uploadDriveItemByteArray(self.httpClient, path, byteArray, mimeType); 
     }
 
     # Upload a new file to the Drive. This method only supports files up to 4MB in size.
@@ -445,17 +446,17 @@ public client class Client {
     #                      the new folder only.    
     # + fileName - The name of the new file
     # + byteArray - An array of `byte` that represents a binary form of the file to be uploaded
-    # + mediaType - The media type of the uploading file
-    # + return - A record of type `DriveItem` if sucess. Else `Error`.
+    # + mimeType - The mime type of the uploading file
+    # + return - A record of type `DriveItemData` if sucess. Else `Error`.
     @display {label: "Upload file (Path based)"}
     remote isolated function uploadFileToFolderByPath(@display {label: "Parent Folder Path"} string parentFolderPath, 
                                                       @display {label: "File Name"} string fileName, 
                                                       @display {label: "Array of bytes"} byte[] byteArray, 
-                                                      @display {label: "Media Type"} string mediaType) returns 
-                                                      @tainted DriveItem|Error {
+                                                      @display {label: "Mime Type"} string mimeType) returns 
+                                                      @tainted DriveItemData|Error {
         string path = check createPathBasedUrl([LOGGED_IN_USER, DRIVE_RESOURCE, DRIVE_ROOT], 
             string `${parentFolderPath}/${fileName}`, [CONTENT_OF_DRIVE_ITEM]);
-        return uploadDriveItemByteArray(self.httpClient, <@untainted>path, byteArray, mediaType); 
+        return uploadDriveItemByteArray(self.httpClient, path, byteArray, mimeType); 
     }
 
     # Update the contents of an existing file in the Drive. This method only supports files up to 4MB in size.
@@ -463,16 +464,16 @@ public client class Client {
     # 
     # + itemId - The ID of the DriveItem
     # + byteArray - An array of `byte` that represents a binary form of the file to be uploaded
-    # + mediaType - The media type of the uploading file
-    # + return - A record of type `DriveItem` if sucess. Else `Error`.
+    # + mimeType - The mime type of the uploading file
+    # + return - A record of type `DriveItemData` if sucess. Else `Error`.
     @display {label: "Replace file (ID based)"}
-    remote isolated function replaceFileUsingId(@display {label: "Item Id"} string itemId, 
+    remote isolated function replaceFileUsingId(@display {label: "Item ID"} string itemId, 
                                                 @display {label: "Array of bytes"} byte[] byteArray, 
-                                                @display {label: "Media Type"} string mediaType) returns 
-                                                @tainted DriveItem|Error {
+                                                @display {label: "Mime Type"} string mimeType) returns 
+                                                @tainted DriveItemData|Error {
         string path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, ALL_DRIVE_ITEMS, itemId, 
             CONTENT_OF_DRIVE_ITEM]);
-        return uploadDriveItemByteArray(self.httpClient, <@untainted>path, byteArray, mediaType); 
+        return uploadDriveItemByteArray(self.httpClient, path, byteArray, mimeType); 
     }
 
     # Update the contents of an existing file in the Drive. This method only supports files up to 4MB in size.
@@ -481,16 +482,16 @@ public client class Client {
     # + itemPath - The file system path of the File. The hierarchy of the path allowed in this function is relative
     #              to the `root` of the respective Drive. So, the relative path from `root` must be provided.    
     # + byteArray - An array of `byte` that represents a binary form of the file to be uploaded
-    # + mediaType - The media type of the uploading file
-    # + return - A record of type `DriveItem` if sucess. Else `Error`.
+    # + mimeType - The mime type of the uploading file
+    # + return - A record of type `DriveItemData` if sucess. Else `Error`.
     @display {label: "Replace file (Path based)"}
     remote isolated function replaceFileUsingPath(@display {label: "Item Path Relative to Drive Root"} string itemPath,                                                    
                                                   @display {label: "Array of bytes"} byte[] byteArray, 
-                                                  @display {label: "Media Type"} string mediaType) returns 
-                                                  @tainted DriveItem|Error {
+                                                  @display {label: "Mime Type"} string mimeType) returns 
+                                                  @tainted DriveItemData|Error {
         string path = check createPathBasedUrl([LOGGED_IN_USER, DRIVE_RESOURCE, DRIVE_ROOT], itemPath, 
             [CONTENT_OF_DRIVE_ITEM]);
-        return uploadDriveItemByteArray(self.httpClient, <@untainted>path, byteArray, mediaType); 
+        return uploadDriveItemByteArray(self.httpClient, path, byteArray, mimeType); 
     }
     //******************************************************************************************************************
 
@@ -504,46 +505,46 @@ public client class Client {
     #                  5-10 MiB (5,242,880 bytes - 10,485,760 bytes)
     #                  **Note:** For more information about upload large files, refer here: 
     #                  https://docs.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_createuploadsession?view=odsp-graph-online#best-practices
-    # + return - A record of type `DriveItem` if sucess. Else `Error`.
+    # + return - A record of type `DriveItemData` if sucess. Else `Error`.
     @display {label: "Upload a large file"}
     remote function resumableUploadDriveItem(@display {label: "Item Path Relative to Drive Root"} string itemPath, 
-                                             @display {label: "Information About File"} ItemInfo itemInfo, 
+                                             @display {label: "Information About File"} UploadMetadata itemInfo, 
                                              @display {label: "Stream of bytes"} 
                                              stream<io:Block,io:Error?> binaryStream) returns 
-                                             @tainted DriveItem|Error { 
+                                             @tainted DriveItemData|Error { 
         string path = check createPathBasedUrl([DRIVE_RESOURCE, DRIVE_ROOT], itemPath, [CREATE_UPLOAD_SESSION_ACTION]);
         json payload = {
             item: check mapItemInfoToJson(itemInfo)
         };        
-        http:Response response = check self.httpClient->post(<@untainted>path, payload);
+        http:Response response = check self.httpClient->post(path, payload);
         map<json>|string? handledResponse = check handleResponse(response);
         if (handledResponse is map<json>) {
             UploadSession session = check handledResponse.cloneWithType(UploadSession);
-
             int remainingBytes = itemInfo.fileSize;
             int startByte = ZERO;
             int endByte = ZERO;
-            map<json> finalData = {};
-            error? e = binaryStream.forEach(function(io:Block byteBlock) {
-                if (byteBlock.length() < MAXIMUM_FRAGMENT_SIZE) {
-                    endByte = startByte + (byteBlock.length()-1);
-                    if (remainingBytes < byteBlock.length()) {
-                        byte[] lastByteArray = byteBlock.slice(ZERO, remainingBytes);
-                        finalData = <@untainted>checkpanic uploadBytes(itemInfo.fileSize, lastByteArray, startByte, 
-                            endByte, <@untainted>session?.uploadUrl);
-                        log:printInfo("Upload successful");
+                map<json> finalData = {};
+                error? e = binaryStream.forEach(function(io:Block byteBlock) {
+                    if (byteBlock.length() < MAXIMUM_FRAGMENT_SIZE) {
+                        endByte = startByte + (byteBlock.length()-1);
+                        if (remainingBytes < byteBlock.length()) {
+                            byte[] lastByteArray = byteBlock.slice(ZERO, remainingBytes);
+                            finalData = <@untainted>checkpanic uploadBytes(itemInfo.fileSize, lastByteArray, startByte, 
+                                endByte, <@untainted>session?.uploadUrl);
+                            log:printInfo("Upload successful");
+                        } else {
+                            finalData = <@untainted>checkpanic uploadBytes(itemInfo.fileSize, byteBlock, startByte, endByte, 
+                                <@untainted>session?.uploadUrl);
+                            startByte += byteBlock.length();
+                            remainingBytes -= byteBlock.length();
+                            log:printInfo("Remaining bytes to upload: " + remainingBytes.toString() + " bytes");
+                        }
                     } else {
-                        finalData = <@untainted>checkpanic uploadBytes(itemInfo.fileSize, byteBlock, startByte, endByte, 
-                            <@untainted>session?.uploadUrl);
-                        startByte += byteBlock.length();
-                        remainingBytes -= byteBlock.length();
-                        log:printInfo("Remaining bytes to upload: " + remainingBytes.toString() + " bytes");
+                        panic error InputValidationError(MAX_FRAGMENT_SIZE_EXCEEDED);
                     }
-                } else {
-                    panic error InputValidationError(MAX_FRAGMENT_SIZE_EXCEEDED);
-                }
-            });
-            return check convertToDriveItem(finalData);
+                });
+                return check convertToDriveItem(finalData);
+            
         } else {
             return error PayloadValidationError(INVALID_RESPONSE);
         }
@@ -556,16 +557,16 @@ public client class Client {
     # + queryParams - Optional query parameters. This method support OData query parameters to customize the response.
     #                 It should be an array of type `string` in the format `<QUERY_PARAMETER_NAME>=<PARAMETER_VALUE>`
     #                 **Note:** Refer more information about query parameters here: https://docs.microsoft.com/en-us/graph/query-parameters
-    # + return - A stream of type `DriveItem` if sucess. Else `Error`.
+    # + return - A stream of type `DriveItemData` if sucess. Else `Error`.
     @display {label: "Search drive items"}
     remote isolated function searchDriveItems(@display {label: "Search text"} string searchText, 
                                               @display {label: "Optional Query Parameters"} string[] queryParams = []) 
                                               returns @tainted @display {label: "DriveItem Stream"} 
-                                              stream<DriveItem, Error>|Error {
+                                              stream<DriveItemData, Error>|Error {
         string path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, DRIVE_ROOT, 
             string `search(q='${searchText}')`]);
-        DriveItemStream objectInstance = check new (self.httpClient, <@untainted>path);
-        stream<DriveItem, error> finalStream = new (objectInstance);
+        DriveItemStream objectInstance = check new (self.httpClient, path);
+        stream<DriveItemData, error> finalStream = new (objectInstance);
         return finalStream;
     }
 
@@ -581,13 +582,13 @@ public client class Client {
     #             application is requesting.
     # + return - A record of type `Permission` if sucess. Else `Error`.
     @display {label: "Get sharable links (ID based)"}
-    remote isolated function getSharableLinkFromId(@display {label: "Item Id"} string itemId, 
+    remote isolated function getSharableLinkFromId(@display {label: "Item ID"} string itemId, 
                                                    @display {label: "Permission options"} PermissionOptions options) 
                                                    returns @tainted @display {label: "Permission Information"} 
                                                    Permission|Error {
         string path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, ALL_DRIVE_ITEMS, itemId, 
             CREATE_LINK_ACTION]);
-        return check getSharableLink(self.httpClient, <@untainted>path, options);
+        return check getSharableLink(self.httpClient, path, options);
     }
 
     # Create a new sharing link if the specified link type doesn't already exist for the 
@@ -606,16 +607,16 @@ public client class Client {
                                                      returns @tainted Permission|Error {
         string path = check createPathBasedUrl([LOGGED_IN_USER, DRIVE_RESOURCE, DRIVE_ROOT], itemPath, 
             [CREATE_LINK_ACTION]);
-        return check getSharableLink(self.httpClient, <@untainted>path, options);
+        return check getSharableLink(self.httpClient, path, options);
     }
 
     # Access a shared DriveItem by using sharing URL.
     # 
     # + sharingUrl - The URL that represents a sharing link reated for a DriveItem
-    # + return - A record of type `DriveItem` if sucess. Else `Error`.
+    # + return - A record of type `DriveItemData` if sucess. Else `Error`.
     @display {label: "Get shared item metadata"}
     remote isolated function getSharedDriveItem(@display {label: "Shared URL"} string sharingUrl) returns 
-                                                @tainted DriveItem|Error {
+                                                @tainted DriveItemData|Error {
         string encodedSharingUrl = encodeSharingUrl(sharingUrl);
         string path = check createUrl([SHARED_RESOURCES, encodedSharingUrl, DRIVEITEM_RESOURCE]);
         http:Response response = check self.httpClient->get(path);
@@ -634,12 +635,12 @@ public client class Client {
     # + invitation - A record of type `ItemShareInvitation` that contain metadata for sharing
     # + return - A record of type `Permission` if sucess. Else `Error`.
     @display {label: "Send Sharing Invitation (ID based)"}
-    remote isolated function sendSharingInvitationById(@display {label: "Item Id"} string itemId, 
+    remote isolated function sendSharingInvitationById(@display {label: "Item ID"} string itemId, 
                                                        @display {label: "Sharing Invitation"} 
                                                        ItemShareInvitation invitation) returns 
                                                        @tainted Permission|Error { 
         string path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, ALL_DRIVE_ITEMS, itemId, INVITE_ACTION]);
-        return check sendSharableLink(self.httpClient, <@untainted>path, invitation);
+        return check sendSharableLink(self.httpClient, path, invitation);
     }
 
     # Sends a sharing invitation for a DriveItem. A sharing invitation provides permissions to the recipients and
@@ -656,33 +657,33 @@ public client class Client {
                                                          ItemShareInvitation invitation) returns 
                                                          @tainted Permission|Error {
         string path = check createPathBasedUrl([LOGGED_IN_USER, DRIVE_RESOURCE, DRIVE_ROOT], itemPath, [INVITE_ACTION]);
-        return check sendSharableLink(self.httpClient, <@untainted>path, invitation);
+        return check sendSharableLink(self.httpClient, path, invitation);
     }
 
     // *************************Supported only in Azure work and School accounts (NOT TESTED) **************************
-    // remote isolated function checkInDriveItem(@display {label: "Item Id"} string itemId, CheckInOptions options) 
+    // remote isolated function checkInDriveItem(@display {label: "Item ID"} string itemId, CheckInOptions options) 
     //                                           returns @tainted Error? {
     //     string path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, ALL_DRIVE_ITEMS, itemId,
     //         CHECK_IN_ACTION]);
     //     json payload = check options.cloneWithType(json);
-    //     http:Response response = check self.httpClient->post(<@untainted>path, payload);
+    //     http:Response response = check self.httpClient->post(path, payload);
     //     _ = check handleResponse(response);
     // }
 
-    // remote isolated function checkOutDriveItem(@display {label: "Item Id"} string itemId) returns @tainted Error? {
+    // remote isolated function checkOutDriveItem(@display {label: "Item ID"} string itemId) returns @tainted Error? {
     //     string path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, ALL_DRIVE_ITEMS, itemId, 
     //         CHECK_OUT_ACTION]);
     //     http:Request request = new;
-    //     http:Response response = check self.httpClient->post(<@untainted>path, request);
+    //     http:Response response = check self.httpClient->post(path, request);
     //     _ = check handleResponse(response);
     // }
 
-    // remote isolated function followDriveItem(@display {label: "Item Id"} string itemId) returns 
-    //                                          @tainted DriveItem|Error {
+    // remote isolated function followDriveItem(@display {label: "Item ID"} string itemId) returns 
+    //                                          @tainted DriveItemData|Error {
     //     string path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, ALL_DRIVE_ITEMS, itemId, 
     //         FOLLOW_ACTION]);
     //     http:Request request = new;
-    //     http:Response response = check self.httpClient->post(<@untainted>path, request);
+    //     http:Response response = check self.httpClient->post(path, request);
     //     map<json>|string? handledResponse = check handleResponse(response);
     //     if (handledResponse is map<json>) {
     //         return check convertToDriveItem(handledResponse);
@@ -691,20 +692,20 @@ public client class Client {
     //     } 
     // }
 
-    // remote isolated function unfollowDriveItem(@display {label: "Item Id"} string itemId) returns @tainted Error? {
+    // remote isolated function unfollowDriveItem(@display {label: "Item ID"} string itemId) returns @tainted Error? {
     //     string path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, ALL_DRIVE_ITEMS, itemId, 
     //         UNFOLLOW_ACTION]);
     //     http:Request request = new;
-    //     http:Response response = check self.httpClient->post(<@untainted>path, request);
+    //     http:Response response = check self.httpClient->post(path, request);
     //     _ = check handleResponse(response);
     // }
 
-    // remote isolated function getItemsFollowed() returns @tainted DriveItem[]|Error {
+    // remote isolated function getItemsFollowed() returns @tainted DriveItemData[]|Error {
     //     string path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, FOLLOWING_BY_LOGGED_IN_USER]);
-    //     return check getDriveItemArray(self.httpClient, <@untainted>path);
+    //     return check getDriveItemArray(self.httpClient, path);
     // }
     
-    // remote isolated function getDriveItemPreview(@display {label: "Item Id"} string itemId, 
+    // remote isolated function getDriveItemPreview(@display {label: "Item ID"} string itemId, 
     //                                              PreviewOptions? options = ()) returns 
     //                                              @tainted EmbeddableData|Error {
     //     string path = check createUrl([LOGGED_IN_USER, DRIVE_RESOURCE, ALL_DRIVE_ITEMS, itemId, 
@@ -714,7 +715,7 @@ public client class Client {
     //         json payload = check options.cloneWithType(json);
     //         request.setJsonPayload(payload);
     //     }
-    //     http:Response response = check self.httpClient->post(<@untainted>path, request);
+    //     http:Response response = check self.httpClient->post(path, request);
     //     map<json>|string? handledResponse = check handleResponse(response);
     //     if (handledResponse is map<json>) {
     //         return check handledResponse.cloneWithType(EmbeddableData);
@@ -723,10 +724,10 @@ public client class Client {
     //     }
     // }
 
-    // remote isolated function getItemStatistics(string driveId, @display {label: "Item Id"} string itemId) returns 
+    // remote isolated function getItemStatistics(string driveId, @display {label: "Item ID"} string itemId) returns 
     //                                            @tainted ItemAnalytics|Error {
     //     string path = check createUrl([ALL_DRIVES, driveId, ALL_DRIVE_ITEMS, itemId, ANALYTICS_RESOURCES]);
-    //     http:Response response = check self.httpClient->get(<@untainted>path);
+    //     http:Response response = check self.httpClient->get(path);
     //     map<json>|string? handledResponse = check handleResponse(response);
     //     if (handledResponse is map<json>) {
     //         return check handledResponse.cloneWithType(ItemAnalytics);
@@ -735,3 +736,16 @@ public client class Client {
     //     }
     // }
 }
+
+# Resource that provides information about how to upload large files to OneDrive
+#
+# + uploadUrl - The URL endpoint that accepts PUT requests for byte ranges of the file 
+# + expirationDateTime - The date and time in UTC that the upload session will expire. The complete file must be 
+#                        uploaded before this expiration time is reached.
+# + nextExpectedRanges - A collection of byte ranges that the server is missing for the file. These ranges are zero 
+#                        indexed and of the format "start-end" (e.g. "0-26" to indicate the first 27 bytes of the file)
+type UploadSession record {
+    string uploadUrl;
+    string expirationDateTime?;
+    string[] nextExpectedRanges?;
+};

--- a/onedrive/constants.bal
+++ b/onedrive/constants.bal
@@ -86,6 +86,28 @@ public enum PublicationLevel {
     CHECKOUT_LEVEL = "checkout"
 }
 
+public enum SortBy {
+    DEFAULT = "default",
+    NAME = "name",
+    TYPE = "type",
+    SIZE = "size",
+    CREATEDDATETIME = "takenOrCreatedDateTime",
+    LASTMODIFIEDDATETIME = "lastModifiedDateTime",
+    SEQUENCE = "sequence"
+}
+
+public enum SortOrder {
+    ASCENDING = "ascending",
+    DESCENDING = "descending"
+}
+
+public enum ViewType {
+    DEFAULT_VIEWTYPE = "default",
+    ICONS_VIEWTYPE = "icons",
+    DETAILS_VIEWTYPE = "details",
+    THUMBNAILS_VIEWTYPE = "thumbnails"
+}
+
 # The default fragment size for obtaining fragments of a file.(To upload as fragment size MUST be a multiple of 320 KiB 
 # (327,680 bytes)).
 public const DEFAULT_FRAGMENT_SIZE = 327680;

--- a/onedrive/data_mappings.bal
+++ b/onedrive/data_mappings.bal
@@ -14,23 +14,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
-isolated function convertToDriveItem(map<json> sourceDriveItemObject) returns DriveItem|error {
-    DriveItem convertedItem = check sourceDriveItemObject.cloneWithType(DriveItem);
+isolated function convertToDriveItem(map<json> sourceDriveItemObject) returns DriveItemData|error {
+    DriveItemData convertedItem = check sourceDriveItemObject.cloneWithType(DriveItemData);
     convertedItem.downloadUrl = let var url = sourceDriveItemObject["@microsoft.graph.downloadUrl"] in url is string ?
-        url : EMPTY_STRING;
+         url : EMPTY_STRING;
     return convertedItem;
 }
 
-isolated function convertToDriveItemArray(json[] sourceDriveItemObject) returns DriveItem[]|error {
-    DriveItem[] driveItems = [];
+isolated function convertToDriveItemArray(json[] sourceDriveItemObject) returns DriveItemData[]|error {
+    DriveItemData[] driveItems = [];
     foreach json item in sourceDriveItemObject {
-        DriveItem convertedItem = check convertToDriveItem(<map<json>>item);
+        DriveItemData convertedItem = check convertToDriveItem(<map<json>>item);
         driveItems.push(convertedItem);
     }
     return driveItems;
 }
 
-isolated function mapItemInfoToJson(ItemInfo? info) returns json|error {
+isolated function mapItemInfoToJson(UploadMetadata? info) returns json|error {
     json fileInfo = check info?.fileSystemInfo.cloneWithType(json);
     return {
         description: let var desc = info?.description in desc is string ? desc : (), 

--- a/onedrive/drive.bal
+++ b/onedrive/drive.bal
@@ -1,0 +1,245 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/http;
+import ballerina/io;
+
+isolated function getDriveItemArray(http:Client httpClient, string url) returns @tainted DriveItemData[]|Error {
+    http:Response response = check httpClient->get(url);
+    map<json>|string? handledResponse = check handleResponse(response);
+    if (handledResponse is map<json>) {
+        io:println(handledResponse);
+        json responseArray = check handledResponse.value;
+        return check convertToDriveItemArray(<json[]>responseArray);
+    } else {
+        return error PayloadValidationError(INVALID_RESPONSE);
+    }
+}
+
+isolated function getDriveItem(http:Client httpClient, string url) returns @tainted DriveItemData|Error {
+    http:Response response = check httpClient->get(url);
+    map<json>|string? handledResponse = check handleResponse(response);
+    if (handledResponse is map<json>) {
+        io:println(handledResponse);
+
+        return check convertToDriveItem(handledResponse);
+    } else {
+        return error PayloadValidationError(INVALID_RESPONSE);
+    }
+}
+
+isolated function createFolder(http:Client httpClient, string url, FolderMetadata metaData) returns 
+                               @tainted DriveItemData|Error {
+    json payload = check metaData.cloneWithType(json);
+    _ = check payload.mergeJson({"@microsoft.graph.conflictBehavior": metaData?.conflictResolutionBehaviour});
+    http:Response response = check httpClient->post(url, payload);
+    map<json>|string? handledResponse = check handleResponse(response);
+    if (handledResponse is map<json>) {
+        return check convertToDriveItem(handledResponse);
+    } else {
+        return error PayloadValidationError(INVALID_RESPONSE);
+    }   
+}
+
+isolated function updateDriveItem(http:Client httpClient, string url, DriveItem replacementData) returns 
+                                  @tainted DriveItemData|Error {
+    json payload = check replacementData.cloneWithType(json);
+    http:Response response = check httpClient->patch(url, payload);
+    map<json>|string? handledResponse = check handleResponse(response);
+    if (handledResponse is map<json>) {
+        return check convertToDriveItem(handledResponse);
+    } else {
+        return error PayloadValidationError(INVALID_RESPONSE);
+    } 
+}
+
+isolated function downloadDriveItem(http:Client httpClient, string url) returns @tainted File|Error {
+    http:Response response = check httpClient->get(<@untainted>url);
+    if (response.statusCode is http:STATUS_OK) {
+        byte[] content = check response.getBinaryPayload();
+        return {
+            content: content,
+            mimeType: response.getContentType()
+        };  
+    } else {
+        json errorPayload = check response.getJsonPayload();
+        string message = errorPayload.toString(); // Error should be defined as a user defined object
+        return error PayloadValidationError(message);
+    }
+}
+
+isolated function handleDownloadPrtialItem(string webUrl, map<string> headerMap) returns @tainted File|Error {
+    http:Client downloadClient = check new(webUrl);
+    http:Response response = check downloadClient->get(EMPTY_STRING, headerMap);
+    if (response.statusCode is http:STATUS_OK|http:STATUS_PARTIAL_CONTENT) {
+        byte[] content = check response.getBinaryPayload();
+        return {
+            content: content,
+            mimeType: response.getContentType()
+        }; 
+    } else {
+        json errorPayload = check response.getJsonPayload();
+        string message = errorPayload.toString(); // Error should be defined as a user defined object
+        return error PayloadValidationError(message);
+    }
+}
+
+isolated function uploadDriveItem(http:Client httpClient, string url, stream<byte[],io:Error?> binaryStream, 
+                                  string mediaType) returns @tainted DriveItemData|Error {
+    http:Request request = new;
+    request.setByteStream(binaryStream, mediaType);
+    http:Response response = check httpClient->put(url, request);
+    map<json>|string? handledResponse = check handleResponse(response);
+    if (handledResponse is map<json>) {
+        return check convertToDriveItem(handledResponse);
+    } else {
+        return error PayloadValidationError(INVALID_RESPONSE);
+    } 
+}
+
+//************************ Functions for uploading and replacing the files using byte[] ****************************
+isolated function uploadDriveItemByteArray(http:Client httpClient, string url, byte[] byteArray, string mediaType) 
+                                           returns @tainted DriveItemData|Error {
+    http:Request request = new;
+    request.setBinaryPayload(byteArray, mediaType);
+    http:Response response = check httpClient->put(url, request);
+    map<json>|string? handledResponse = check handleResponse(response);
+    if (handledResponse is map<json>) {
+        return check convertToDriveItem(handledResponse);
+    } else {
+        return error PayloadValidationError(INVALID_RESPONSE);
+    } 
+}
+//******************************************************************************************************************
+
+isolated function uploadBytes(int fileSize, byte[] block, int startByte, int endByte, string uploadUrl) returns 
+                              @tainted map<json>|Error {
+    http:Client uploadClient = check new(uploadUrl, {
+        timeout: REQUEST_TIMEOUT,
+        http1Settings: {chunking: http:CHUNKING_NEVER},
+        retryConfig : {
+            count: RETRY_ATTEMPTS,
+            interval: RETRY_INTERVAL,
+            backOffFactor: BACKOFF_FACTOR,
+            maxWaitInterval: MAX_WAIT,
+            statusCodes: [http:STATUS_BAD_GATEWAY, http:STATUS_SERVICE_UNAVAILABLE, http:STATUS_GATEWAY_TIMEOUT, 
+                http:STATUS_HTTP_VERSION_NOT_SUPPORTED, http:STATUS_INTERNAL_SERVER_ERROR]
+        }
+    });
+    http:Request request = new;
+    string contentRangeHeader = string `bytes ${startByte.toString()}-${endByte.toString()}/${fileSize.toString()}`;
+    map<string> headers = {
+        [CONTENT_RANGE]: contentRangeHeader,
+        [http:CONTENT_LENGTH]: block.length().toString()
+    };
+    setSpecficRequestHeaders(request, headers);
+    request.setBinaryPayload(block);
+    http:Response response = check uploadClient->put(EMPTY_STRING, request);
+    map<json>|string? handledResponse = check handleResumableUploadResponse(response, uploadUrl);
+    if (handledResponse is map<json>) {
+        return handledResponse;
+    } else {
+        return error PayloadValidationError(INVALID_RESPONSE);
+    }
+}
+
+isolated function handleResumableUploadResponse(http:Response httpResponse, string uploadUrl) returns 
+                                                @tainted map<json>|Error? {
+    if (httpResponse.statusCode is http:STATUS_OK|http:STATUS_CREATED|http:STATUS_ACCEPTED) {
+        json jsonResponse = check httpResponse.getJsonPayload();
+        return <map<json>>jsonResponse;
+    } else if (httpResponse.statusCode is http:STATUS_NOT_FOUND) {
+
+    }
+    json errorPayload = check httpResponse.getJsonPayload();
+    string message = errorPayload.toString(); // Error should be defined as a user defined object
+    return error PayloadValidationError(message);
+}
+
+# Sets required request headers.
+# 
+# + request - Request object reference
+# + specificRequiredHeaders - Request headers as a key value map
+isolated function setSpecficRequestHeaders(http:Request request, map<string> specificRequiredHeaders) {
+    string[] keys = specificRequiredHeaders.keys();
+    foreach string keyItem in keys {
+        request.setHeader(keyItem, specificRequiredHeaders.get(keyItem));
+    }
+}
+
+isolated function getSharableLink(http:Client httpClient, string url, PermissionOptions options) returns 
+                                  @tainted Permission|Error {
+    json permissionOptions = check options.cloneWithType(json);
+    http:Response response = check httpClient->post(url, permissionOptions);
+    map<json>|string? handledResponse = check handleResponse(response);
+    if (handledResponse is map<json>) {
+        return check handledResponse.cloneWithType(Permission);
+    } else {
+        return error PayloadValidationError(INVALID_RESPONSE);
+    }
+}
+
+isolated function sendSharableLink(http:Client httpClient, string url, ItemShareInvitation invitation) returns 
+                                   @tainted Permission|Error {
+    boolean isValid = let var message = invitation?.message in message is string ? message.length() >= MAX_CHAR_COUNT ? 
+        false : true : true; 
+    if (!isValid) {
+        return error PayloadValidationError(INVALID_MESSAGE);
+    }              
+    json shareInvitation = check invitation.cloneWithType(json);
+    http:Response response = check httpClient->post(url, shareInvitation);
+    map<json>|string? handledResponse = check handleResponse(response);
+    if (handledResponse is map<json>) {
+        return check handledResponse.cloneWithType(Permission);
+    } else {
+        return error PayloadValidationError(INVALID_RESPONSE);
+    }
+}
+
+isolated function copyDriveItem(http:Client httpClient, string url, ParentReference? parentReference, string? name) 
+                                returns @tainted string|Error {
+    json copyItemOptions = {};
+    if ((name is () || name == "") &&  parentReference is ()) {
+        copyItemOptions = {};
+    } else if (parentReference is ()) {
+        copyItemOptions = { name: name };
+    } else if (name is () || name == "") {
+        copyItemOptions = { parentReference : check parentReference.cloneWithType(json) };
+    } else {
+        copyItemOptions = {
+                            parentReference : check parentReference.cloneWithType(json),
+                            name: name
+                          };
+    }      
+    http:Response response = check httpClient->post(url, copyItemOptions);
+    map<json>|string? handledResponse = check handleCopyItemResponse(response);
+    if (handledResponse is string) {
+        return handledResponse;
+    } else {
+        return error PayloadValidationError(INVALID_RESPONSE);
+    }
+}
+
+isolated function handleCopyItemResponse(http:Response httpResponse) returns @tainted string|Error? {
+    if (httpResponse.statusCode == http:STATUS_ACCEPTED) {
+        // long running JOB
+        string locationHeader = check httpResponse.getHeader(http:LOCATION);
+        AsyncJobStatus asyncStatus = check getasyncJobStatus(<@untainted>locationHeader); 
+        return asyncStatus?.resourceId;
+    }
+    json errorPayload = check httpResponse.getJsonPayload();
+    string message = errorPayload.toString(); // Error should be defined as a user defined object
+    return error PayloadValidationError(message);
+}

--- a/onedrive/samples/create_folder_by_id.bal
+++ b/onedrive/samples/create_folder_by_id.bal
@@ -44,9 +44,9 @@ public function main() returns error? {
         conflictResolutionBehaviour : "rename"
     };
 
-    onedrive:DriveItem|onedrive:Error driveItem = driveClient->createFolderById(parentID, item);
+    onedrive:DriveItemData|onedrive:Error driveItem = driveClient->createFolderById(parentID, item);
 
-    if (driveItem is onedrive:DriveItem) {
+    if (driveItem is onedrive:DriveItemData) {
         log:printInfo("Folder Created " + driveItem.toString());
         log:printInfo("Success!");
     } else {

--- a/onedrive/samples/create_folder_by_path.bal
+++ b/onedrive/samples/create_folder_by_path.bal
@@ -44,9 +44,9 @@ public function main() returns error? {
         conflictResolutionBehaviour : "rename"
     };
 
-    onedrive:DriveItem|onedrive:Error driveItem = driveClient->createFolderByPath(parentRelativepath, item);
+    onedrive:DriveItemData|onedrive:Error driveItem = driveClient->createFolderByPath(parentRelativepath, item);
 
-    if (driveItem is onedrive:DriveItem) {
+    if (driveItem is onedrive:DriveItemData) {
         log:printInfo("Folder Created " + driveItem.toString());
         log:printInfo("Success!");
     } else {

--- a/onedrive/samples/get_item_metadata_by_id.bal
+++ b/onedrive/samples/get_item_metadata_by_id.bal
@@ -39,9 +39,9 @@ public function main() returns error? {
 
     string itemId = "<ITEM_ID>";
 
-    onedrive:DriveItem|onedrive:Error driveItem = driveClient->getItemMetadataById(itemId);
+    onedrive:DriveItemData|onedrive:Error driveItem = driveClient->getItemMetadataById(itemId);
 
-    if (driveItem is onedrive:DriveItem) {
+    if (driveItem is onedrive:DriveItemData) {
         log:printInfo(driveItem.toString());
         log:printInfo("Success!");
     } else {

--- a/onedrive/samples/get_item_metadata_by_id_query_params.bal
+++ b/onedrive/samples/get_item_metadata_by_id_query_params.bal
@@ -40,9 +40,9 @@ public function main() returns error? {
     string itemId = "<ITEM_ID>";
     string[] queryParams = ["$expand=children"];
 
-    onedrive:DriveItem|onedrive:Error driveItem = driveClient->getItemMetadataById(itemId, queryParams);
+    onedrive:DriveItemData|onedrive:Error driveItem = driveClient->getItemMetadataById(itemId, queryParams);
 
-    if (driveItem is onedrive:DriveItem) {
+    if (driveItem is onedrive:DriveItemData) {
         log:printInfo(driveItem.toString());
         log:printInfo("Success!");
     } else {

--- a/onedrive/samples/get_item_metatada_by_path.bal
+++ b/onedrive/samples/get_item_metatada_by_path.bal
@@ -39,9 +39,9 @@ public function main() returns error? {
 
     string itemPath = "<ITEM_PATH>";
 
-    onedrive:DriveItem|onedrive:Error driveItem = driveClient->getItemMetadataByPath(itemPath);
+    onedrive:DriveItemData|onedrive:Error driveItem = driveClient->getItemMetadataByPath(itemPath);
 
-    if (driveItem is onedrive:DriveItem) {
+    if (driveItem is onedrive:DriveItemData) {
         log:printInfo(driveItem.toString());
         log:printInfo("Success!");
     } else {

--- a/onedrive/samples/get_recent_items.bal
+++ b/onedrive/samples/get_recent_items.bal
@@ -36,9 +36,9 @@ public function main() returns error? {
     onedrive:Client driveClient = check new(configuration);
 
     log:printInfo("Get recent items");
-    onedrive:DriveItem[]|onedrive:Error driveItems = driveClient->getRecentItems();
+    onedrive:DriveItemData[]|onedrive:Error driveItems = driveClient->getRecentItems();
 
-    if (driveItems is onedrive:DriveItem[]) {
+    if (driveItems is onedrive:DriveItemData[]) {
         foreach var item in driveItems {
             log:printInfo("Item received " + item.toString());
         }

--- a/onedrive/samples/get_shared_drive_item.bal
+++ b/onedrive/samples/get_shared_drive_item.bal
@@ -39,8 +39,8 @@ public function main() returns error? {
 
     string sharedUrl = "<SHARED_URL>";
 
-    onedrive:DriveItem|onedrive:Error sharedItem = driveClient->getSharedDriveItem(sharedUrl);
-    if (sharedItem is onedrive:DriveItem) {
+    onedrive:DriveItemData|onedrive:Error sharedItem = driveClient->getSharedDriveItem(sharedUrl);
+    if (sharedItem is onedrive:DriveItemData) {
         log:printInfo("Shared item info " + sharedItem.toString());
         log:printInfo("Success!");
     } else {

--- a/onedrive/samples/get_shared_items.bal
+++ b/onedrive/samples/get_shared_items.bal
@@ -37,9 +37,9 @@ public function main() returns error? {
 
     log:printInfo("Get items shared with me");
 
-    onedrive:DriveItem[]|onedrive:Error driveItems = driveClient->getItemsSharedWithMe();
+    onedrive:DriveItemData[]|onedrive:Error driveItems = driveClient->getItemsSharedWithMe();
 
-    if (driveItems is onedrive:DriveItem[]) {
+    if (driveItems is onedrive:DriveItemData[]) {
         foreach var item in driveItems {
             log:printInfo("Item received " + item.toString());
         }

--- a/onedrive/samples/move_drive_item_by_id.bal
+++ b/onedrive/samples/move_drive_item_by_id.bal
@@ -45,8 +45,8 @@ public function main() returns error? {
             id: parentFolderId
         }
     };
-    onedrive:DriveItem|onedrive:Error driveItem = driveClient->updateDriveItemById(itemId, replacement);
-    if (driveItem is onedrive:DriveItem) {
+    onedrive:DriveItemData|onedrive:Error driveItem = driveClient->updateDriveItemById(itemId, replacement);
+    if (driveItem is onedrive:DriveItemData) {
         log:printInfo("Item moved " + driveItem.toString());
         log:printInfo("Success!");
     } else {

--- a/onedrive/samples/replace_file_using_id.bal
+++ b/onedrive/samples/replace_file_using_id.bal
@@ -42,8 +42,8 @@ public function main() returns error? {
     string fileId = "<FILE_ID>";
     string mediType = "image/png";
 
-    onedrive:DriveItem|onedrive:Error itemInfo = driveClient->replaceFileUsingId(fileId, byteArray, mediType);
-    if (itemInfo is onedrive:DriveItem) {
+    onedrive:DriveItemData|onedrive:Error itemInfo = driveClient->replaceFileUsingId(fileId, byteArray, mediType);
+    if (itemInfo is onedrive:DriveItemData) {
         log:printInfo("Replaced item " + itemInfo?.id.toString());
         log:printInfo("Success!");
     } else {

--- a/onedrive/samples/replace_file_using_path.bal
+++ b/onedrive/samples/replace_file_using_path.bal
@@ -42,8 +42,8 @@ public function main() returns error? {
     string filePath = "<FILE_PATH>";
     string mediType = "image/png";
 
-    onedrive:DriveItem|onedrive:Error itemInfo = driveClient->replaceFileUsingPath(filePath, byteArray, mediType);
-    if (itemInfo is onedrive:DriveItem) {
+    onedrive:DriveItemData|onedrive:Error itemInfo = driveClient->replaceFileUsingPath(filePath, byteArray, mediType);
+    if (itemInfo is onedrive:DriveItemData) {
         log:printInfo("Replaced item " + itemInfo?.id.toString());
         log:printInfo("Success!");
     } else {

--- a/onedrive/samples/restore_drive_item.bal
+++ b/onedrive/samples/restore_drive_item.bal
@@ -39,8 +39,8 @@ public function main() returns error? {
 
     string itemId = "<ITEM_ID>";
 
-    onedrive:DriveItem|onedrive:Error restoredDriveItem = driveClient->restoreDriveItem(itemId);
-    if (restoredDriveItem is onedrive:DriveItem) {
+    onedrive:DriveItemData|onedrive:Error restoredDriveItem = driveClient->restoreDriveItem(itemId);
+    if (restoredDriveItem is onedrive:DriveItemData) {
         log:printInfo("Item restored "+ restoredDriveItem?.id.toString());
         log:printInfo("Success!");
     } else {

--- a/onedrive/samples/search_drive_items.bal
+++ b/onedrive/samples/search_drive_items.bal
@@ -39,9 +39,9 @@ public function main() returns error? {
     
     string searchText = "<SEARCH_TEXT>";
 
-    stream<onedrive:DriveItem, onedrive:Error>|onedrive:Error itemStream = driveClient->searchDriveItems(searchText);
-    if (itemStream is stream<onedrive:DriveItem, onedrive:Error>) {
-        onedrive:Error? e = itemStream.forEach(isolated function (onedrive:DriveItem queryResult) {
+    stream<onedrive:DriveItemData, onedrive:Error>|onedrive:Error itemStream = driveClient->searchDriveItems(searchText);
+    if (itemStream is stream<onedrive:DriveItemData, onedrive:Error>) {
+        onedrive:Error? e = itemStream.forEach(isolated function (onedrive:DriveItemData queryResult) {
             log:printInfo(queryResult.toString());
         });
         log:printInfo("Success!");

--- a/onedrive/samples/update_drive_item_by_id.bal
+++ b/onedrive/samples/update_drive_item_by_id.bal
@@ -47,8 +47,8 @@ public function main() returns error? {
             childCount: 9
         }
     };
-    onedrive:DriveItem|onedrive:Error driveItem = driveClient->updateDriveItemById(itemId, replacement);
-    if (driveItem is onedrive:DriveItem) {
+    onedrive:DriveItemData|onedrive:Error driveItem = driveClient->updateDriveItemById(itemId, replacement);
+    if (driveItem is onedrive:DriveItemData) {
         log:printInfo("Item updated " + driveItem.toString());
         log:printInfo("Success!");
     } else {

--- a/onedrive/samples/update_drive_item_by_path.bal
+++ b/onedrive/samples/update_drive_item_by_path.bal
@@ -43,8 +43,8 @@ public function main() returns error? {
         folder : {}
     };
 
-    onedrive:DriveItem|onedrive:Error driveItem = driveClient->updateDriveItemByPath(itemPath, replacement);
-    if (driveItem is onedrive:DriveItem) {
+    onedrive:DriveItemData|onedrive:Error driveItem = driveClient->updateDriveItemByPath(itemPath, replacement);
+    if (driveItem is onedrive:DriveItemData) {
         log:printInfo("Item updated " + driveItem.toString());
         log:printInfo("Success!");
     } else {

--- a/onedrive/samples/upload_file_to_parent_id.bal
+++ b/onedrive/samples/upload_file_to_parent_id.bal
@@ -43,9 +43,9 @@ public function main() returns error? {
     string parentFolderId = "<PARENT_FOLDER_ID>";
     string mediaType = "image/png";
 
-    onedrive:DriveItem|onedrive:Error itemInfo = driveClient->uploadDriveItemToFolderById(parentFolderId, 
+    onedrive:DriveItemData|onedrive:Error itemInfo = driveClient->uploadFileToFolderById(parentFolderId, 
         fileNameForNewUploadById, byteArray, mediaType);
-    if (itemInfo is onedrive:DriveItem) {
+    if (itemInfo is onedrive:DriveItemData) {
         log:printInfo("Uploaded item " + itemInfo?.id.toString());
         log:printInfo("Success!");
     } else {

--- a/onedrive/samples/upload_file_to_parent_path.bal
+++ b/onedrive/samples/upload_file_to_parent_path.bal
@@ -43,9 +43,9 @@ public function main() returns error? {
     string parentFolderPath = "<PARENT_FOLDER_PATH>";
     string mediaType = "image/png";
 
-    onedrive:DriveItem|onedrive:Error itemInfo = driveClient->uploadDriveItemToFolderByPath(parentFolderPath, 
+    onedrive:DriveItemData|onedrive:Error itemInfo = driveClient->uploadFileToFolderByPath(parentFolderPath, 
         fileNameNewForNewUploadByPath, byteArray, mediaType);
-    if (itemInfo is onedrive:DriveItem) {
+    if (itemInfo is onedrive:DriveItemData) {
         log:printInfo("Uploaded item " + itemInfo?.id.toString());
         log:printInfo("Success!");
     } else {

--- a/onedrive/samples/upload_large_file.bal
+++ b/onedrive/samples/upload_large_file.bal
@@ -45,13 +45,13 @@ public function main() returns error? {
         onedrive:DEFAULT_FRAGMENT_SIZE*8);
     file:MetaData fileMetaData = check file:getMetaData(localFilePath);
     string uploadDestinationPath = "<UPLOAD_DETINATION_FILE_PATH_WITH_EXTENTION>";
-    onedrive:ItemInfo info = {
+    onedrive:UploadMetadata info = {
         fileSize : fileMetaData.size
     };
 
-    onedrive:DriveItem|onedrive:Error itemInfo = driveClient->resumableUploadDriveItem(uploadDestinationPath, info, 
+    onedrive:DriveItemData|onedrive:Error itemInfo = driveClient->resumableUploadDriveItem(uploadDestinationPath, info, 
         fileStream);
-    if (itemInfo is onedrive:DriveItem) {
+    if (itemInfo is onedrive:DriveItemData) {
         log:printInfo("Uploaded item " + itemInfo?.id.toString());
         log:printInfo("Success!");
     } else {

--- a/onedrive/tests/test.bal
+++ b/onedrive/tests/test.bal
@@ -64,8 +64,8 @@ function testCreateFoldersAndFiles() {
         conflictResolutionBehaviour : "rename"
     };
 
-    DriveItem|Error driveItem = oneDriveClient->createFolderById(parentID, item);
-    if (driveItem is DriveItem) {
+    DriveItemData|Error driveItem = oneDriveClient->createFolderById(parentID, item);
+    if (driveItem is DriveItemData) {
         log:printInfo("Folder Created");
         collectorFolderId = <@untainted>driveItem?.id.toString();
         collectorFolderPath = "/"+ <@untainted>driveItem?.name.toString();
@@ -77,30 +77,12 @@ function testCreateFoldersAndFiles() {
 @test:Config {
     enable: true
 }
-function testGetRecentItems() {
-    log:printInfo("client->getRecentItems()");
-    runtime:sleep(2);
-
-    DriveItem[]|Error driveItems = oneDriveClient->getRecentItems();
-    if (driveItems is DriveItem[]) {
-        foreach var item in driveItems {
-            log:printInfo("Item received " + item.toString());
-        }
-    } else {
-        test:assertFail(msg = driveItems.message());
-    }
-    io:println("\n\n");
-}
-
-@test:Config {
-    enable: true
-}
 function testGetItemsSharedWithMe() {
     log:printInfo("client->getItemsSharedWithMe()");
     runtime:sleep(2);
 
-    DriveItem[]|Error driveItems = oneDriveClient->getItemsSharedWithMe();
-    if (driveItems is DriveItem[]) {
+    DriveItemData[]|Error driveItems = oneDriveClient->getItemsSharedWithMe();
+    if (driveItems is DriveItemData[]) {
         foreach var item in driveItems {
             log:printInfo("Item received " + item.toString());
         }
@@ -122,10 +104,18 @@ function testCreateFolderById() {
 
     FolderMetadata item = {
         name: newFolderName,
+        folder: {
+            childCount: 10,
+            view: {
+                sortBy: "name",
+                sortOrder: "descending", // But no effect can be seen
+                viewType: "details"
+            }
+        },
         conflictResolutionBehaviour : "rename"
     };
-    DriveItem|Error driveItem = oneDriveClient->createFolderById(parentID, item);
-    if (driveItem is DriveItem) {
+    DriveItemData|Error driveItem = oneDriveClient->createFolderById(parentID, item);
+    if (driveItem is DriveItemData) {
         log:printInfo("Folder Created " + driveItem?.id.toString());
         newFolderId = <@untainted>driveItem?.id.toString();
     } else {
@@ -149,8 +139,8 @@ function testCreateFolderByPath() {
         name: newFolderName,
         conflictResolutionBehaviour : "rename"
     };
-    DriveItem|Error driveItem = oneDriveClient->createFolderByPath(parentRelativepath, item);
-    if (driveItem is DriveItem) {
+    DriveItemData|Error driveItem = oneDriveClient->createFolderByPath(parentRelativepath, item);
+    if (driveItem is DriveItemData) {
         log:printInfo("Folder Created " + driveItem?.id.toString());
     } else {
         test:assertFail(msg = driveItem.message());
@@ -168,8 +158,8 @@ function testGetItemMetadataById() {
 
     string itemId = newFolderId;
     
-    DriveItem|Error driveItem = oneDriveClient->getItemMetadataById(itemId);
-    if (driveItem is DriveItem) {
+    DriveItemData|Error driveItem = oneDriveClient->getItemMetadataById(itemId);
+    if (driveItem is DriveItemData) {
         log:printInfo("Item received " + driveItem.toString());
     } else {
         test:assertFail(msg = driveItem.message());
@@ -186,8 +176,8 @@ function testGetItemMetadataByPath() {
     runtime:sleep(2);
 
     string itemPath = newFolderPath;
-    DriveItem|Error driveItem = oneDriveClient->getItemMetadataByPath(itemPath);
-    if (driveItem is DriveItem) {
+    DriveItemData|Error driveItem = oneDriveClient->getItemMetadataByPath(itemPath);
+    if (driveItem is DriveItemData) {
         log:printInfo("Item received " + driveItem.toString());
     } else {
         test:assertFail(msg = driveItem.message());
@@ -206,8 +196,8 @@ function testGetItemMetadataByIdApplyQueryParams() {
     string itemId = collectorFolderId;
     string[] queryParams = ["$expand=children"];
 
-    DriveItem|Error driveItem = oneDriveClient->getItemMetadataById(itemId, queryParams);
-    if (driveItem is DriveItem) {
+    DriveItemData|Error driveItem = oneDriveClient->getItemMetadataById(itemId, queryParams);
+    if (driveItem is DriveItemData) {
         log:printInfo("Item received " + driveItem.toString());
     } else {
         test:assertFail(msg = driveItem.message());
@@ -233,8 +223,8 @@ function testUpdateDriveItemById() {
             childCount: 9
         }
     };
-    DriveItem|Error driveItem = oneDriveClient->updateDriveItemById(itemId, replacement);
-    if (driveItem is DriveItem) {
+    DriveItemData|Error driveItem = oneDriveClient->updateDriveItemById(itemId, replacement);
+    if (driveItem is DriveItemData) {
         log:printInfo("Item updated " + driveItem.toString());
     } else {
         test:assertFail(msg = driveItem.message());
@@ -255,8 +245,8 @@ function testUpdateDriveItemByPath() {
         name: "Child_Canva",
         folder : {}
     };
-    DriveItem|Error driveItem = oneDriveClient->updateDriveItemByPath(itemPath, replacement);
-    if (driveItem is DriveItem) {
+    DriveItemData|Error driveItem = oneDriveClient->updateDriveItemByPath(itemPath, replacement);
+    if (driveItem is DriveItemData) {
         log:printInfo("Item updated " + driveItem.toString());
         newFolderPath = "/Child_Canva";
     } else {
@@ -283,8 +273,8 @@ function testMoveDriveItem() {
         }
     };
 
-    DriveItem|Error driveItemMovedById = oneDriveClient->updateDriveItemById(itemIdtoMoveById, replacement1);
-    if (driveItemMovedById is DriveItem) {
+    DriveItemData|Error driveItemMovedById = oneDriveClient->updateDriveItemById(itemIdtoMoveById, replacement1);
+    if (driveItemMovedById is DriveItemData) {
         log:printInfo("Item moved " + driveItemMovedById.toString());
     } else {
         test:assertFail(msg = driveItemMovedById.message());
@@ -301,8 +291,8 @@ function testMoveDriveItem() {
         }
     };
 
-    DriveItem|Error driveItemMovedByPath = oneDriveClient->updateDriveItemByPath(itemPathtoMoveByPath, replacement2);
-    if (driveItemMovedByPath is DriveItem) {
+    DriveItemData|Error driveItemMovedByPath = oneDriveClient->updateDriveItemByPath(itemPathtoMoveByPath, replacement2);
+    if (driveItemMovedByPath is DriveItemData) {
         log:printInfo("Item moved " + driveItemMovedByPath.toString());
         collectorCopyFolderPath = collectorFolderPath + "/Moved_to_Collector_Path";
     } else {
@@ -358,8 +348,8 @@ function testRestoreDriveItem() {
 
     string itemId = collectorCopyIdFolderId;
 
-    DriveItem|Error restoredDriveItem = oneDriveClient->restoreDriveItem(itemId);
-    if (restoredDriveItem is DriveItem) {
+    DriveItemData|Error restoredDriveItem = oneDriveClient->restoreDriveItem(itemId);
+    if (restoredDriveItem is DriveItemData) {
         log:printInfo("Item restored "+ restoredDriveItem?.id.toString());
     } else {
         test:assertFail(msg = restoredDriveItem.message());
@@ -424,9 +414,9 @@ function testCopyDriveItemInPath() {
 //     string parentFolderId = collectorFolderId;
 //     string mediaType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 
-//     DriveItem|Error itemInfo = oneDriveClient->uploadFileToFolderById(parentFolderId, fileNameForNewUploadById, 
+//     DriveItemData|Error itemInfo = oneDriveClient->uploadFileToFolderById(parentFolderId, fileNameForNewUploadById, 
 //         byteStream, mediaType);
-//     if (itemInfo is DriveItem) {
+//     if (itemInfo is DriveItemData) {
 //         log:printInfo("Uploaded item " + itemInfo?.id.toString());
 //         idOfFileInCollector = <@untainted>itemInfo?.id.toString();
 //     } else {
@@ -447,9 +437,9 @@ function testCopyDriveItemInPath() {
 //     string parentFolderPath = collectorFolderPath;
 //     string mediaType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 
-//     DriveItem|Error itemInfo = oneDriveClient->uploadFileToFolderByPath(parentFolderPath, 
+//     DriveItemData|Error itemInfo = oneDriveClient->uploadFileToFolderByPath(parentFolderPath, 
 //         fileNameNewForNewUploadByPath, byteStream, mediaType);
-//     if (itemInfo is DriveItem) {
+//     if (itemInfo is DriveItemData) {
 //         log:printInfo("Uploaded item " + itemInfo?.id.toString());
 //         pathOfFileInCollector = collectorFolderPath + FORWARD_SLASH + fileNameNewForNewUploadByPath;
 //     } else {
@@ -470,8 +460,8 @@ function testCopyDriveItemInPath() {
 //     string fileId = idOfFileInCollector;
 //     string mediType = "image/png";
 
-//     DriveItem|Error itemInfo = oneDriveClient->replaceFileUsingId(fileId, byteStream, mediType);
-//     if (itemInfo is DriveItem) {
+//     DriveItemData|Error itemInfo = oneDriveClient->replaceFileUsingId(fileId, byteStream, mediType);
+//     if (itemInfo is DriveItemData) {
 //         log:printInfo("Replaced item " + itemInfo?.id.toString());
 //     } else {
 //         test:assertFail(msg = itemInfo.message());
@@ -491,8 +481,8 @@ function testCopyDriveItemInPath() {
 //     string filePath = pathOfFileInCollector;
 //     string mediType = "image/png";
 
-//     DriveItem|Error itemInfo = oneDriveClient->replaceFileUsingPath(filePath, byteStream, mediType);
-//     if (itemInfo is DriveItem) {
+//     DriveItemData|Error itemInfo = oneDriveClient->replaceFileUsingPath(filePath, byteStream, mediType);
+//     if (itemInfo is DriveItemData) {
 //         log:printInfo("Replaced item " + itemInfo?.id.toString());
 //     } else {
 //         test:assertFail(msg = itemInfo.message());
@@ -516,9 +506,9 @@ function testUploadFileToFolderByIdAsArray() {
     string parentFolderId = collectorFolderId;
     string mediaType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 
-    DriveItem|Error itemInfo = oneDriveClient->uploadFileToFolderById(parentFolderId, fileNameForNewUploadById, 
+    DriveItemData|Error itemInfo = oneDriveClient->uploadFileToFolderById(parentFolderId, fileNameForNewUploadById, 
         byteArray, mediaType);
-    if (itemInfo is DriveItem) {
+    if (itemInfo is DriveItemData) {
         log:printInfo("Uploaded item " + itemInfo?.id.toString());
         idOfFileInCollector = <@untainted>itemInfo?.id.toString();
     } else {
@@ -540,9 +530,9 @@ function testUploadFileToFolderByPathAsArray() {
     string parentFolderPath = collectorFolderPath;
     string mediaType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 
-    DriveItem|Error itemInfo = oneDriveClient->uploadFileToFolderByPath(parentFolderPath, 
+    DriveItemData|Error itemInfo = oneDriveClient->uploadFileToFolderByPath(parentFolderPath, 
         fileNameNewForNewUploadByPath, byteArray, mediaType);
-    if (itemInfo is DriveItem) {
+    if (itemInfo is DriveItemData) {
         log:printInfo("Uploaded item " + itemInfo?.id.toString());
         pathOfFileInCollector = collectorFolderPath + FORWARD_SLASH + fileNameNewForNewUploadByPath;
     } else {
@@ -563,8 +553,8 @@ function testReplaceFileUsingIdAsArray() {
     string fileId = idOfFileInCollector;
     string mediType = "image/png";
 
-    DriveItem|Error itemInfo = oneDriveClient->replaceFileUsingId(fileId, byteArray, mediType);
-    if (itemInfo is DriveItem) {
+    DriveItemData|Error itemInfo = oneDriveClient->replaceFileUsingId(fileId, byteArray, mediType);
+    if (itemInfo is DriveItemData) {
         log:printInfo("Replaced item " + itemInfo?.id.toString());
     } else {
         test:assertFail(msg = itemInfo.message());
@@ -584,8 +574,8 @@ function testReplaceFileUsingPathAsArray() {
     string filePath = pathOfFileInCollector;
     string mediType = "image/png";
 
-    DriveItem|Error itemInfo = oneDriveClient->replaceFileUsingPath(filePath, byteArray, mediType);
-    if (itemInfo is DriveItem) {
+    DriveItemData|Error itemInfo = oneDriveClient->replaceFileUsingPath(filePath, byteArray, mediType);
+    if (itemInfo is DriveItemData) {
         log:printInfo("Replaced item " + itemInfo?.id.toString());
     } else {
         test:assertFail(msg = itemInfo.message());
@@ -692,12 +682,12 @@ function testResumableUploadDriveItem() {
     stream<io:Block,io:Error?> fileStream = checkpanic io:fileReadBlocksAsStream(localFilePath, DEFAULT_FRAGMENT_SIZE*6);
     file:MetaData fileMetaData = checkpanic file:getMetaData(localFilePath);
     string uploadDestinationPath = collectorFolderPath + FORWARD_SLASH + fileName;
-    ItemInfo info = {
+    UploadMetadata info = {
         fileSize : fileMetaData.size
     };
 
-    DriveItem|Error itemInfo = oneDriveClient->resumableUploadDriveItem(uploadDestinationPath, info, fileStream);
-    if (itemInfo is DriveItem) {
+    DriveItemData|Error itemInfo = oneDriveClient->resumableUploadDriveItem(uploadDestinationPath, info, fileStream);
+    if (itemInfo is DriveItemData) {
         log:printInfo("Uploaded item " + itemInfo?.id.toString());
     } else {
         test:assertFail(msg = itemInfo.message());
@@ -706,17 +696,16 @@ function testResumableUploadDriveItem() {
 }
 
 @test:Config {
-    enable: true,
-    dependsOn: []
+    enable: true
 }
 function testSearchDriveItems() {
     log:printInfo("client->searchDriveItems()");
     runtime:sleep(2);
 
     string searchText = "newUploadByPath";
-    stream<DriveItem, Error>|Error itemStream = oneDriveClient->searchDriveItems(searchText);
-    if (itemStream is stream<DriveItem, Error>) {
-        Error? e = itemStream.forEach(isolated function (DriveItem queryResult) {
+    stream<DriveItemData, Error>|Error itemStream = oneDriveClient->searchDriveItems(searchText);
+    if (itemStream is stream<DriveItemData, Error>) {
+        Error? e = itemStream.forEach(isolated function (DriveItemData queryResult) {
             log:printInfo(queryResult.toString());
         });
     } else {
@@ -781,8 +770,8 @@ function testGetSharedDriveItem() {
     log:printInfo("client->getSharedDriveItem()");
     runtime:sleep(2);
 
-    DriveItem|Error sharedItem = oneDriveClient->getSharedDriveItem(sharedUrl);
-    if (sharedItem is DriveItem) {
+    DriveItemData|Error sharedItem = oneDriveClient->getSharedDriveItem(sharedUrl);
+    if (sharedItem is DriveItemData) {
         log:printInfo("Shared item info " + sharedItem.toString());
     } else {
         test:assertFail(msg = sharedItem.message());
@@ -845,16 +834,19 @@ function testSendSharingInvitationByPath() {
 
 // *************************Supported only in Azure work and School accounts (NOT TESTED) **************************
 // @test:Config {
-//     enable: true
+//     enable: true,
+//     dependsOn: [testRestoreDriveItem]
 // }
 // function testCheckInDriveItem() {
 //     log:printInfo("client->checkInDriveItem()");
 //     runtime:sleep(2);
 
+//     string itemId = collectorCopyIdFolderId;
+
 //     CheckInOptions options = {
 //         comment: "Check In"
 //     };
-//     error? result = oneDriveClient->checkInDriveItem(checkedInFile, options);
+//     error? result = oneDriveClient->checkInDriveItem(itemId, options);
 //     if (result is ()) {
 //         log:printInfo("CheckIn success");
 //     } else {
@@ -887,8 +879,8 @@ function testSendSharingInvitationByPath() {
 //     log:printInfo("client->followDriveItem()");
 //     runtime:sleep(2);
 
-//     DriveItem|Error followedDeiveItem = oneDriveClient->followDriveItem(followFile);
-//     if (followedDeiveItem is DriveItem) {
+//     DriveItemData|Error followedDeiveItem = oneDriveClient->followDriveItem(followFile);
+//     if (followedDeiveItem is DriveItemData) {
 //         log:printInfo("Item followed "+ followedDeiveItem?.id.toString());
 //     } else {
 //         test:assertFail(msg = followedDeiveItem.message());
@@ -918,8 +910,8 @@ function testSendSharingInvitationByPath() {
 //     log:printInfo("client->getItemsFollowed()");
 //     runtime:sleep(2);
 
-//     DriveItem[]|Error driveItems = oneDriveClient->getItemsFollowed();
-//     if (driveItems is DriveItem[]) {
+//     DriveItemData[]|Error driveItems = oneDriveClient->getItemsFollowed();
+//     if (driveItems is DriveItemData[]) {
 //         foreach var item in driveItems {
 //             log:printInfo("Item received " + item.toString());
 //         }

--- a/onedrive/types.bal
+++ b/onedrive/types.bal
@@ -510,7 +510,7 @@ public type DriveItem record {|
 # + conflictResolutionBehaviour - The conflict resolution behaviour
 public type FolderMetadata record {|
     string name;
-    Folder folder = { }; //check with kanushka
+    Folder folder = { };
     ItemReference parentReference?;
     FileSystemInfo fileSystemInfo?;
     ConflictResolutionBehaviour conflictResolutionBehaviour?;

--- a/onedrive/types.bal
+++ b/onedrive/types.bal
@@ -16,35 +16,95 @@
 
 import ballerina/http;
 
-# Represents configuration parameters to create Azure Cosmos DB client.
+# Represents configuration parameters to create Microsoft OneDrive client.
 #
 # + clientConfig - OAuth client configuration
 # + secureSocketConfig - SSH configuration
 @display{label: "Connection config"} 
-public type Configuration record {
+public type Configuration record {|
     http:BearerTokenConfig|http:OAuth2RefreshTokenGrantConfig clientConfig;
     http:ClientSecureSocket secureSocketConfig?;
-};
+|};
 
-# An abstract resource that contains a common set of properties shared among several other resources types.
+# Represents a file, folder, or other item stored in a drive.
 #
 # + id - The unique identifier of the drive
-# + description - Provides a user-visible description of the item
-# + createdBy - Identity of the user, device, or application which created the item 
 # + createdDateTime - Date and time of item creation
+# + cTag - An eTag for the content of the item. This eTag is not changed if only the metadata is changed. 
+#          **Note:** This property is not returned if the item is a folder.
 # + eTag - ETag for the item
-# + lastModifiedBy - Identity of the user, device, and application which last modified the item 
 # + lastModifiedDateTime - Date and time the item was last modified 
+# + name - Name of the item
+# + size - Size of the item in bytes 
 # + webUrl - URL that displays the resource in the browser
-public type BaseItem record {
+# + description - Provides a user-visible description of the item
+# + webDavUrl - WebDAV compatible URL for the item 
+# + root - If this property is non-null, it indicates that the driveItem is the top-most driveItem in the drive
+# + createdBy - Identity of the user, device, or application which created the item 
+# + lastModifiedBy - Identity of the user, device, and application which last modified the item
+# + fileSystemInfo - File system information on client
+# + parentReference - Parent information, if the item has a parent
+# + remoteItem - Remote item data, if the item is shared from a drive other than the one being accessed
+# + downloadUrl - A URL that can be used to download this file's content. Authentication is not required with this URL. 
+# + file - File metadata, if the item is a file
+# + folder - Folder metadata, if the item is a folder
+# + image - Image metadata, if the item is an image 
+# + photo - Photo metadata, if the item is a photo 
+# + video - Video metadata, if the item is a video
+# + audio - Audio metadata, if the item is an audio file 
+# + location - Location metadata, if the item has location data 
+# + package - If present, indicates that this item is a package instead of a folder or file
+# + publication - Provides information about the published or checked-out state of an item, in locations that support 
+#                 such actions
+# + deleted - Information about the deleted state of the item
+# + shared - Indicates that the item has been shared with others and provides information about the shared state of the 
+# + searchResult - Search metadata, if the item is from a search result item
+# + sharepointIds - Returns identifiers useful for SharePoint REST compatibility
+# + specialFolder - If the current item is also available as a special folder, this facet is returned
+# + children - Collection containing Item objects for the immediate children of item
+# + versions - The list of previous versions of the item 
+# + activities - The list of recent activities that took place on this item
+# + permissions - The set of permissions for the item 
+# + thumbnails - Collection containing ThumbnailSet objects associated with the item
+public type DriveItemData record {
     string id?;
-    string description?;
-    IdentitySet createdBy?;
     string createdDateTime?;
+    string cTag?;
     string eTag?;
-    IdentitySet lastModifiedBy?;
     string lastModifiedDateTime?;
+    string name?;
+    int size?;
     string webUrl?;
+    string description?;
+    string webDavUrl?;
+    json root?;
+    IdentitySet createdBy?;
+    IdentitySet lastModifiedBy?;
+    FileSystemInfo fileSystemInfo?;
+    ItemReference parentReference?;
+    DriveItemData remoteItem?;
+    string downloadUrl?;
+    File file?;
+    Folder folder?;
+    Image image?;
+    Photo photo?;
+    Video video?;
+    Audio audio?;
+    GeoCordinates location?;
+    Package package?;
+    Publication publication?;
+    Deleted deleted?;
+    Shared shared?;
+    SearchResult searchResult?;
+    SharePointId sharepointIds?;
+    SpecialFolder specialFolder?;
+    // relationships
+    DriveItemData[] children?;
+    DriveItemVersion[] versions?;
+    ItemActivity activities?;
+    Permission[] permissions?;
+    ThumbnailSet[] thumbnails?;
+    // instance annotations
 };
 
 # represent a set of identities associated with various events for an item.
@@ -67,6 +127,18 @@ public type Identity record {
     string id?;
 };
 
+# Resource that contains properties that are reported by the device's local file system for the local version of an 
+# item.
+#
+# + createdDateTime - The UTC date and time the file was created on a client
+# + lastAccessedDateTime - The UTC date and time the file was last accessed 
+# + lastModifiedDateTime - The UTC date and time the file was last modified on a client
+public type FileSystemInfo record {
+    string createdDateTime?;
+    string lastAccessedDateTime?;
+    string lastModifiedDateTime?;
+};
+
 # Provides information necessary to address a DriveItem via the API.
 #
 # + driveId - Unique identifier of the drive instance that contains the item 
@@ -76,7 +148,6 @@ public type Identity record {
 # + path - Path that can be used to navigate to the item
 # + shareId - A unique identifier for a shared resource that can be accessed via the Shares API
 # + sharepointIds - Returns identifiers useful for SharePoint REST compatibility
-# + siteId - represents the ID of the site that contains the parent document library of the driveItem resource 
 public type ItemReference record {
     string driveId?;
     string driveType?;
@@ -85,94 +156,106 @@ public type ItemReference record {
     string path?;
     string shareId?;
     SharePointId sharepointIds?;
-    string siteId?;
 };
 
-# Represents a file, folder, or other item stored in a drive.
+# Resource that groups file-related data items into a single structure.
 #
-# + cTag - An eTag for the content of the item. This eTag is not changed if only the metadata is changed. 
-#          **Note:** This property is not returned if the item is a folder.
-# + description - Provides a user-visible description of the item
-# + size - Size of the item in bytes 
-# + name - The name of the folder
-# + webDavUrl - WebDAV compatible URL for the item 
-# + audio - Audio metadata, if the item is an audio file 
-# + image - Image metadata, if the item is an image 
-# + file - File metadata, if the item is a file
-# + location - Location metadata, if the item has location data 
-# + package - If present, indicates that this item is a package instead of a folder or file
-# + photo - Photo metadata, if the item is a photo 
-# + publication - Provides information about the published or checked-out state of an item, in locations that support 
-#                 such actions
-# + video - Video metadata, if the item is a video
-# + deleted - Information about the deleted state of the item
-# + searchResult - Search metadata, if the item is from a search result
-# + shared - Indicates that the item has been shared with others and provides information about the shared state of the 
-#            item
-# + sharepointIds - Returns identifiers useful for SharePoint REST compatibility
-# + specialFolder - If the current item is also available as a special folder, this facet is returned
-# + fileSystemInfo - File system information on client
-# + remoteItem - Remote item data, if the item is shared from a drive other than the one being accessed 
-# + folder - Folder metadata, if the item is a folder
-# + root - If this property is non-null, it indicates that the driveItem is the top-most driveItem in the drive
-# + parentReference - Parent information, if the item has a parent
-# + children - Collection containing Item objects for the immediate children of item
-# + versions - The list of previous versions of the item 
-# + activities - The list of recent activities that took place on this item
-# + permissions - The set of permissions for the item 
-# + thumbnails - Collection containing ThumbnailSet objects associated with the item
-# + downloadUrl - A URL that can be used to download this file's content. Authentication is not required with this URL. 
-public type DriveItem record {|
-    *BaseItem;
-    string cTag?;
-    string description?;
-    int size?;
-    string name?;
-    string webDavUrl?;
-    Audio audio?;
-    Image image?;
-    File file?;
-    GeoCordinates location?;
-    Package package?;
-    Photo photo?;
-    Publication publication?;
-    Video video?;
-    Deleted deleted?;
-    SearchResult searchResult?;
-    Shared shared?;
-    SharePointId sharepointIds?;
-    SpecialFolder specialFolder?;
-    FileSystemInfo fileSystemInfo?;
-    RemoteItem remoteItem?;
-    Folder folder?;
-    json root?;
-    // relationships
-    ItemReference parentReference?;
-    DriveItem[] children?;
-    DriveItemVersion[] versions?;
-    ItemActivity activities?;
-    Permission[] permissions?;
-    ThumbnailSet[] thumbnails?;
-    // instance annotations
-    string downloadUrl?;
+# + content - A `byte[]` which represents the content of a file
+# + mimeType - The MIME type for the file
+# + hashes - Hashes of the file's binary content, if available
+public type File record {
+    byte[] content?;
+    string mimeType?;
+    Hash hashes?;
+};
+
+# Resource that groups available hashes into a single structure for an item.
+#
+# + crc32Hash - The CRC32 value of the file in little endian (if available)
+# + sha1Hash - SHA1 hash for the contents of the file (if available)
+# + sha256Hash - SHA256 hash for the contents of the file (if available)
+# + quickXorHash - A proprietary hash of the file that can be used to determine if the contents of the file have changed
+public type Hash record {
+    string crc32Hash?;
+    string sha1Hash?;
+    string sha256Hash?;
+    string quickXorHash?;
+};
+
+# Resource that groups folder-related data on an item into a single structure.
+#
+# + childCount - Number of children contained immediately within this container 
+# + view - A collection of properties defining the recommended view for the folder
+public type Folder record {|
+    int:Unsigned32 childCount?;
+    FolderView view?;
 |};
 
-# Represents necessary metadata in reference to a folder.
+# Resource that provides or sets recommendations on the user-experience of a folder.
 #
-# + name - The name of the folder
-# + folder - Folder metadata, if the item is a folder
-# + parentReference - Parent information, if the item has a parent
-# + fileSystemInfo - File system information on client
-# + conflictResolutionBehaviour - The conflict resolution behaviour
-# + remoteItem - Remote item data, if the item is shared from a drive other than the one being accessed 
-public type FolderMetadata record {|
-    string name;
-    Folder folder = { };
-    ItemReference parentReference?;
-    FileSystemInfo fileSystemInfo?;
-    ConflictResolutionBehaviour conflictResolutionBehaviour?;
-    RemoteItem remoteItem?;
-|};
+# + sortBy - The method by which the folder should be sorted 
+# + sortOrder - Indicates that items should be sorted in descending order. Otherwise, items should be sorted ascending.
+# + viewType - The type of view that should be used to represent the folder
+public type FolderView record {
+    SortBy sortBy?;
+    SortOrder sortOrder?;
+    ViewType viewType?;
+};
+
+# Resource that groups image-related properties into a single structure.
+#
+# + width - Width of the image, in pixels 
+# + height - Height of the image, in pixels
+public type Image record {
+    int:Unsigned32 width?;
+    int:Unsigned32 height?;
+};
+
+# Resource that provides photo and camera properties.
+#
+# + cameraMake - Camera manufacturer 
+# + cameraModel - Camera model 
+# + exposureDenominator - The denominator for the exposure time fraction from the camera
+# + exposureNumerator - The numerator for the exposure time fraction from the camera
+# + fNumber - The F-stop value from the camera 
+# + focalLength - The focal length from the camera
+# + iso - The ISO value from the camera
+# + takenDateTime - Represents the date and time the photo was taken
+public type Photo record {
+    string cameraMake?;
+    string cameraModel?;
+    float exposureDenominator?;
+    float exposureNumerator?;
+    float fNumber?;
+    float focalLength?;
+    int:Unsigned32 iso?;
+    string takenDateTime?;
+};
+
+# Resource that groups video-related data items into a single structure.
+#
+# + audioBitsPerSample - Number of audio bits per sample 
+# + audioChannels - Number of audio channels
+# + audioFormat - Name of the audio format (AAC, MP3, etc.) 
+# + audioSamplesPerSecond - Number of audio samples per second
+# + bitrate - Bit rate of the video in bits per second
+# + duration - Duration of the file in milliseconds
+# + fourCC - "Four character code" name of the video format
+# + frameRate - Frame rate of the video
+# + height - Height of the video, in pixels
+# + width - Width of the video, in pixels
+public type Video record {
+    int:Unsigned32 audioBitsPerSample?;
+    int:Unsigned32 audioChannels?;
+    string audioFormat?;
+    int:Unsigned32 audioSamplesPerSecond?;
+    int:Unsigned32 bitrate?;
+    int duration?;
+    string fourCC?;
+    float frameRate?;
+    int:Unsigned32 height?;
+    int:Unsigned32 width?;
+};
 
 # Resource that groups audio-related properties on an item into a single structure.
 #
@@ -211,59 +294,6 @@ public type Audio record {
     int:Unsigned32 year?;
 };
 
-# Resource that groups file-related data items into a single structure.
-#
-# + content - A `byte[]` which represents the content of a file
-# + mediaType - The MIME type for the file
-# + hashes - Hashes of the file's binary content, if available
-public type File record {
-    byte[] content?;
-    string mediaType?;
-    HashFacet hashes?;
-};
-
-# Resource that groups available hashes into a single structure for an item.
-#
-# + crc32Hash - The CRC32 value of the file in little endian (if available)
-# + sha1Hash - SHA1 hash for the contents of the file (if available)
-# + sha256Hash - SHA256 hash for the contents of the file (if available)
-# + quickXorHash - A proprietary hash of the file that can be used to determine if the contents of the file have changed
-public type HashFacet record {
-    string crc32Hash?;
-    string sha1Hash?;
-    string sha256Hash?;
-    string quickXorHash?;
-};
-
-# Resource that groups folder-related data on an item into a single structure.
-#
-# + childCount - Number of children contained immediately within this container 
-# + view - A collection of properties defining the recommended view for the folder
-public type Folder record {
-    int:Unsigned32 childCount?;
-    FolderView view?;
-};
-
-# Resource that provides or sets recommendations on the user-experience of a folder.
-#
-# + sortBy - The method by which the folder should be sorted 
-# + sortOrder - Indicates that items should be sorted in descending order. Otherwise, items should be sorted ascending.
-# + viewType - The type of view that should be used to represent the folder
-public type FolderView record {
-    string sortBy?;
-    string sortOrder?;
-    string viewType?;
-};
-
-# Resource that groups image-related properties into a single structure.
-#
-# + width - Width of the image, in pixels 
-# + height - Height of the image, in pixels
-public type Image record {
-    int:Unsigned32 width?;
-    int:Unsigned32 height?;
-};
-
 # Resource that provides geographic coordinates and elevation of a location based on metadata contained within the file.
 #
 # + altitude - The altitude (height), in feet, above sea level for the item
@@ -283,27 +313,6 @@ public type Package record {
     string 'type?;
 };
 
-# Resource that provides photo and camera properties.
-#
-# + cameraMake - Camera manufacturer 
-# + cameraModel - Camera model 
-# + exposureDenominator - The denominator for the exposure time fraction from the camera
-# + exposureNumerator - The numerator for the exposure time fraction from the camera
-# + fNumber - The F-stop value from the camera 
-# + focalLength - The focal length from the camera
-# + iso - The ISO value from the camera
-# + takenDateTime - Represents the date and time the photo was taken
-public type Photo record {
-    string cameraMake?;
-    string cameraModel?;
-    float exposureDenominator?;
-    float exposureNumerator?;
-    float fNumber?;
-    float focalLength?;
-    int:Unsigned32 iso?;
-    string takenDateTime?;
-};
-
 # Resource that provides details on the published status of a driveItemVersion or driveItem resource.
 #
 # + level - The state of publication for this document. Either `published` or `checkout`. 
@@ -313,97 +322,12 @@ public type Publication record {
     string versionId?;
 };
 
-# Resource that indicates that a driveItem references an item that exists in another drive.
-#
-# + id - Unique identifier for the remote item in its drive 
-# + createdBy - Identity of the user, device, and application which created the item
-# + createdDateTime - Date and time of item creation
-# + file - Indicates that the remote item is a file
-# + fileSystemInfo - Information about the remote item from the local file system
-# + folder - Indicates that the remote item is a folder
-# + lastModifiedBy - Identity of the user, device, and application which last modified the item
-# + lastModifiedDateTime - Date and time the item was last modified
-# + name - Filename of the remote item 
-# + package - If present, indicates that this item is a package instead of a folder or file
-# + parentReference - Properties of the parent of the remote item
-# + shared - Indicates that the item has been shared with others and provides information about the shared state of 
-#            the item
-# + sharepointIds - Provides interop between items in OneDrive for Business and SharePoint with the full set of 
-#                   item identifiers 
-# + specialFolder - If the current item is also available as a special folder, this facet is returned
-# + size - Size of the remote item
-# + webDavUrl - DAV compatible URL for the item 
-# + webUrl - URL that displays the resource in the browser
-public type RemoteItem record {
-    string id?;
-    IdentitySet createdBy?;
-    string createdDateTime?;
-    File file?;
-    FileSystemInfo fileSystemInfo?;
-    Folder folder?;
-    IdentitySet lastModifiedBy?;
-    string lastModifiedDateTime?;
-    string name?;
-    Package package?;
-    ItemReference parentReference?;
-    Shared shared?;
-    SharePointId sharepointIds?;
-    SpecialFolder specialFolder?;
-    int size?;
-    string webDavUrl?;
-    string webUrl?;
-};
-
-# Resource that groups video-related data items into a single structure.
-#
-# + audioBitsPerSample - Number of audio bits per sample 
-# + audioChannels - Number of audio channels
-# + audioFormat - Name of the audio format (AAC, MP3, etc.) 
-# + audioSamplesPerSecond - Number of audio samples per second
-# + bitrate - Bit rate of the video in bits per second
-# + duration - Duration of the file in milliseconds
-# + fourCC - "Four character code" name of the video format
-# + frameRate - Frame rate of the video
-# + height - Height of the video, in pixels
-# + width - Width of the video, in pixels
-public type Video record {
-    int:Unsigned32 audioBitsPerSample?;
-    int:Unsigned32 audioChannels?;
-    string audioFormat?;
-    int:Unsigned32 audioSamplesPerSecond?;
-    int:Unsigned32 bitrate?;
-    int duration?;
-    string fourCC?;
-    float frameRate?;
-    int:Unsigned32 height?;
-    int:Unsigned32 width?;
-};
-
 # Resource that indicates that the item has been deleted. The presence (non-null) of the resource value indicates that 
 # the file was deleted. A null (or missing) value indicates that the file is not deleted.
 #
 # + state - Represents the state of the deleted item 
 public type Deleted record {
     string state?;
-};
-
-# Resource that contains properties that are reported by the device's local file system for the local version of an 
-# item.
-#
-# + createdDateTime - The UTC date and time the file was created on a client
-# + lastAccessedDateTime - The UTC date and time the file was last accessed 
-# + lastModifiedDateTime - The UTC date and time the file was last modified on a client
-public type FileSystemInfo record {
-    string createdDateTime?;
-    string lastAccessedDateTime?;
-    string lastModifiedDateTime?;
-};
-
-# Resource that indicates than an item is the response to a search query.
-#
-# + onClickTelemetryUrl - A callback URL that can be used to record telemetry information. 
-public type SearchResult record {
-    string onClickTelemetryUrl?;
 };
 
 # Resource that indicates a DriveItem has been shared with others.
@@ -417,6 +341,13 @@ public type Shared record {
     string scope?; 
     IdentitySet sharedBy?;
     string sharedDateTime?;
+};
+
+# Resource that indicates than an item is the response to a search query.
+#
+# + onClickTelemetryUrl - A callback URL that can be used to record telemetry information. 
+public type SearchResult record {
+    string onClickTelemetryUrl?;
 };
 
 # Resource that groups the various identifiers for an item stored in a SharePoint site or OneDrive for Business into a 
@@ -471,7 +402,7 @@ public type DriveItemVersion record {
 public type ItemActivity record {
     string id?;
     IdentitySet actor?;
-    DriveItem driveItem?;
+    DriveItemData driveItem?;
     string activityDateTime?;
     //listItem: {@odata.type: microsoft.graph.listItem},
 };
@@ -496,20 +427,6 @@ public type Permission record {
     string[] roles?;
     string shareId?;
 };
-
-# Resource that defines properties of the sharing link your application is requesting. 
-#
-# + 'type - The type of sharing link to create. Either `view`, `edit`, or `embed`
-# + scope - The scope of link to create. Either `anonymous` or `organization`
-# + password - The password of the sharing link that is set by the creator. Optional and OneDrive Personal only.
-# + expirationDateTime - A String with format of yyyy-MM-ddTHH:mm:ssZ of DateTime indicates the expiration time of the 
-#                        permission 
-public type PermissionOptions record {|
-    LinkType 'type;
-    LinkScope scope?;
-    string password?;
-    string expirationDateTime?;
-|};
 
 #  Resource that groups link-related data items into a single structure.
 #
@@ -570,31 +487,57 @@ public type Tumbnail record {
     string url?;
 };
 
-# Resource that provide the progress of the long running action.
+// *********************************************** Input Record Types **************************************************
+# Drive item data
 #
-# + operation - The type of long running operation
-# + percentageComplete - A value between 0 and 100 that indicates the percentage complete 
-# + resourceId - ID of the relevent DriveItem 
-# + status - String value that maps to an enumeration of possible values about the status of the job
-type AsyncJobStatus record {
-    string operation?;
-    float percentageComplete?;
-    string resourceId?;
-    AsyncJobStatusString status?;
-};
+# + name - Name of the item
+# + file - File metadata, if the item is a file
+# + folder - Folder metadata, if the item is a folder 
+# + parentReference - Parent information, if the item has a parent
+public type DriveItem record {|
+    string name?;
+    File file?;
+    Folder folder?;
+    ParentReference parentReference?;
+|};
 
-# Resource that provides information about how to upload large files to OneDrive
+# Represents necessary metadata in reference to a folder.
 #
-# + uploadUrl - The URL endpoint that accepts PUT requests for byte ranges of the file 
-# + expirationDateTime - The date and time in UTC that the upload session will expire. The complete file must be 
-#                        uploaded before this expiration time is reached.
-# + nextExpectedRanges - A collection of byte ranges that the server is missing for the file. These ranges are zero 
-#                        indexed and of the format "start-end" (e.g. "0-26" to indicate the first 27 bytes of the file)
-public type UploadSession record {
-    string uploadUrl;
+# + name - The name of the folder
+# + folder - Folder metadata, if the item is a folder
+# + parentReference - Parent information, if the item has a parent
+# + fileSystemInfo - File system information on client
+# + conflictResolutionBehaviour - The conflict resolution behaviour
+public type FolderMetadata record {|
+    string name;
+    Folder folder = { }; //check with kanushka
+    ItemReference parentReference?;
+    FileSystemInfo fileSystemInfo?;
+    ConflictResolutionBehaviour conflictResolutionBehaviour?;
+|};
+
+# The reference data for the destination folder where the item will be copied
+#
+# + id - ID of the destination folder  
+# + driveId - ID of the Drive the destination folder exist
+public type ParentReference record {|
+    string id;
+    string driveId?;
+|};
+
+# Resource that defines properties of the sharing link your application is requesting. 
+#
+# + 'type - The type of sharing link to create. Either `view`, `edit`, or `embed`
+# + scope - The scope of link to create. Either `anonymous` or `organization`
+# + password - The password of the sharing link that is set by the creator. Optional and OneDrive Personal only.
+# + expirationDateTime - A String with format of yyyy-MM-ddTHH:mm:ssZ of DateTime indicates the expiration time of the 
+#                        permission 
+public type PermissionOptions record {|
+    LinkType 'type;
+    LinkScope scope?;
+    string password?;
     string expirationDateTime?;
-    string[] nextExpectedRanges?;
-};
+|};
 
 # Resource that provide additional data about the file being uploaded and customizing the semantics of the upload 
 # operation.
@@ -604,13 +547,13 @@ public type UploadSession record {
 # + name - The name of the item (filename and extension) 
 # + fileSize - Provides an expected file size to perform a quota check prior to upload. Only on OneDrive Personal.
 # + conflictResolutionBehaviour - The conflict resolution behaviour
-public type ItemInfo record {
+public type UploadMetadata record {|
     int fileSize;
     string name?;
     string description?;
     FileSystemInfo fileSystemInfo?;
     ConflictResolutionBehaviour conflictResolutionBehaviour?;
-};
+|};
 
 # Resource that represents necessary information for a sharing invitation.
 #
@@ -639,6 +582,16 @@ public type DriveRecipient record {|
     string objectId?;
 |};
 
+# Resource that contains the values to define a range of bytes.
+#
+# + startByte - The value of the starting index of bytes  
+# + endByte - The value of the ending index of bytes   
+public type ByteRange record {|
+    int startByte;
+    int endByte;
+|};
+
+// ***************************************** Other Record Types ********************************************************
 # Resource that contains options for Check-In a file.
 #
 # + comment - A check-in comment that is associated with the version
@@ -722,13 +675,4 @@ public type IncompleteData record {|
 public type ItemActionStat record {|
     int:Unsigned32 actionCount;
     int:Unsigned32 actorCount;
-|};
-
-# Resource that contains the values to define a range of bytes.
-#
-# + startByte - The value of the starting index of bytes  
-# + endByte - The value of the ending index of bytes   
-public type ByteRange record {|
-    int startByte;
-    int endByte;
 |};

--- a/onedrive/utils.bal
+++ b/onedrive/utils.bal
@@ -15,7 +15,6 @@
 // under the License.
 
 import ballerina/http;
-import ballerina/io;
 import ballerina/regex;
 
 isolated function handleResponse(http:Response httpResponse) returns @tainted map<json>|Error? {
@@ -113,231 +112,6 @@ isolated function validateOdataSystemQueryOption(string queryOptionName, string 
     return isValid;
 }
 
-isolated function getDriveItemArray(http:Client httpClient, string url) returns @tainted DriveItem[]|Error {
-    http:Response response = check httpClient->get(url);
-    map<json>|string? handledResponse = check handleResponse(response);
-    if (handledResponse is map<json>) {
-        json responseArray = check handledResponse.value;
-        return check convertToDriveItemArray(<json[]>responseArray);
-    } else {
-        return error PayloadValidationError(INVALID_RESPONSE);
-    }
-}
-
-isolated function getDriveItem(http:Client httpClient, string url) returns @tainted DriveItem|Error {
-    http:Response response = check httpClient->get(url);
-    map<json>|string? handledResponse = check handleResponse(response);
-    if (handledResponse is map<json>) {
-        return check convertToDriveItem(handledResponse);
-    } else {
-        return error PayloadValidationError(INVALID_RESPONSE);
-    }
-}
-
-isolated function createFolder(http:Client httpClient, string url, FolderMetadata itemMetadata) returns 
-                               @tainted DriveItem|Error {
-    json payload = check itemMetadata.cloneWithType(json);
-    _ = check payload.mergeJson({"@microsoft.graph.conflictBehavior": itemMetadata?.conflictResolutionBehaviour});
-    http:Response response = check httpClient->post(url, payload);
-    map<json>|string? handledResponse = check handleResponse(response);
-    if (handledResponse is map<json>) {
-        return check convertToDriveItem(handledResponse);
-    } else {
-        return error PayloadValidationError(INVALID_RESPONSE);
-    }   
-}
-
-isolated function updateDriveItem(http:Client httpClient, string url, DriveItem replacementData) returns 
-                                  @tainted DriveItem|Error {
-    json payload = check replacementData.cloneWithType(json);
-    http:Response response = check httpClient->patch(url, payload);
-    map<json>|string? handledResponse = check handleResponse(response);
-    if (handledResponse is map<json>) {
-        return check convertToDriveItem(handledResponse);
-    } else {
-        return error PayloadValidationError(INVALID_RESPONSE);
-    } 
-}
-
-isolated function downloadDriveItem(http:Client httpClient, string url) returns @tainted File|Error {
-    http:Response response = check httpClient->get(<@untainted>url);
-    if (response.statusCode is http:STATUS_OK) {
-        byte[] content = check response.getBinaryPayload();
-        return {
-            content: content,
-            mediaType: response.getContentType()
-        };  
-    } else {
-        json errorPayload = check response.getJsonPayload();
-        string message = errorPayload.toString(); // Error should be defined as a user defined object
-        return error PayloadValidationError(message);
-    }
-}
-
-isolated function handleDownloadPrtialItem(string webUrl, map<string> headerMap) returns @tainted File|Error {
-    http:Client downloadClient = check new(webUrl);
-    http:Response response = check downloadClient->get(EMPTY_STRING, headerMap);
-    if (response.statusCode is http:STATUS_OK|http:STATUS_PARTIAL_CONTENT) {
-        byte[] content = check response.getBinaryPayload();
-        return {
-            content: content,
-            mediaType: response.getContentType()
-        }; 
-    } else {
-        json errorPayload = check response.getJsonPayload();
-        string message = errorPayload.toString(); // Error should be defined as a user defined object
-        return error PayloadValidationError(message);
-    }
-}
-
-isolated function uploadDriveItem(http:Client httpClient, string url, stream<byte[],io:Error?> binaryStream, 
-                                  string mediaType) returns @tainted DriveItem|Error {
-    http:Request request = new;
-    request.setByteStream(binaryStream, mediaType);
-    http:Response response = check httpClient->put(url, request);
-    map<json>|string? handledResponse = check handleResponse(response);
-    if (handledResponse is map<json>) {
-        return check convertToDriveItem(handledResponse);
-    } else {
-        return error PayloadValidationError(INVALID_RESPONSE);
-    } 
-}
-
-//************************ Functions for uploading and replacing the files using byte[] ****************************
-isolated function uploadDriveItemByteArray(http:Client httpClient, string url, byte[] byteArray, string mediaType) 
-                                           returns @tainted DriveItem|Error {
-    http:Request request = new;
-    request.setBinaryPayload(byteArray, mediaType);
-    http:Response response = check httpClient->put(url, request);
-    map<json>|string? handledResponse = check handleResponse(response);
-    if (handledResponse is map<json>) {
-        return check convertToDriveItem(handledResponse);
-    } else {
-        return error PayloadValidationError(INVALID_RESPONSE);
-    } 
-}
-//******************************************************************************************************************
-
-isolated function uploadBytes(int fileSize, byte[] block, int startByte, int endByte, string uploadUrl) returns 
-                              @tainted map<json>|Error {
-    http:Client uploadClient = check new(uploadUrl, {
-        timeout: REQUEST_TIMEOUT,
-        http1Settings: {chunking: http:CHUNKING_NEVER},
-        retryConfig : {
-            count: RETRY_ATTEMPTS,
-            interval: RETRY_INTERVAL,
-            backOffFactor: BACKOFF_FACTOR,
-            maxWaitInterval: MAX_WAIT,
-            statusCodes: [http:STATUS_BAD_GATEWAY, http:STATUS_SERVICE_UNAVAILABLE, http:STATUS_GATEWAY_TIMEOUT, 
-                http:STATUS_HTTP_VERSION_NOT_SUPPORTED, http:STATUS_INTERNAL_SERVER_ERROR]
-        }
-    });
-    http:Request request = new;
-    string contentRangeHeader = string `bytes ${startByte.toString()}-${endByte.toString()}/${fileSize.toString()}`;
-    map<string> headers = {
-        [CONTENT_RANGE]: contentRangeHeader,
-        [http:CONTENT_LENGTH]: block.length().toString()
-    };
-    setSpecficRequestHeaders(request, headers);
-    request.setBinaryPayload(block);
-    http:Response response = check uploadClient->put(EMPTY_STRING, request);
-    map<json>|string? handledResponse = check handleResumableUploadResponse(response, uploadUrl);
-    if (handledResponse is map<json>) {
-        return handledResponse;
-    } else {
-        return error PayloadValidationError(INVALID_RESPONSE);
-    }
-}
-
-isolated function handleResumableUploadResponse(http:Response httpResponse, string uploadUrl) returns 
-                                                @tainted map<json>|Error? {
-    if (httpResponse.statusCode is http:STATUS_OK|http:STATUS_CREATED|http:STATUS_ACCEPTED) {
-        json jsonResponse = check httpResponse.getJsonPayload();
-        return <map<json>>jsonResponse;
-    } else if (httpResponse.statusCode is http:STATUS_NOT_FOUND) {
-
-    }
-    json errorPayload = check httpResponse.getJsonPayload();
-    string message = errorPayload.toString(); // Error should be defined as a user defined object
-    return error PayloadValidationError(message);
-}
-
-# Sets required request headers.
-# 
-# + request - Request object reference
-# + specificRequiredHeaders - Request headers as a key value map
-isolated function setSpecficRequestHeaders(http:Request request, map<string> specificRequiredHeaders) {
-    string[] keys = specificRequiredHeaders.keys();
-    foreach string keyItem in keys {
-        request.setHeader(keyItem, specificRequiredHeaders.get(keyItem));
-    }
-}
-
-isolated function getSharableLink(http:Client httpClient, string url, PermissionOptions options) returns 
-                                  @tainted Permission|Error {
-    json permissionOptions = check options.cloneWithType(json);
-    http:Response response = check httpClient->post(url, permissionOptions);
-    map<json>|string? handledResponse = check handleResponse(response);
-    if (handledResponse is map<json>) {
-        return check handledResponse.cloneWithType(Permission);
-    } else {
-        return error PayloadValidationError(INVALID_RESPONSE);
-    }
-}
-
-isolated function sendSharableLink(http:Client httpClient, string url, ItemShareInvitation invitation) returns 
-                                   @tainted Permission|Error {
-    boolean isValid = let var message = invitation?.message in message is string ? message.length() >= MAX_CHAR_COUNT ? 
-        false : true : true; 
-    if (!isValid) {
-        return error PayloadValidationError(INVALID_MESSAGE);
-    }              
-    json shareInvitation = check invitation.cloneWithType(json);
-    http:Response response = check httpClient->post(url, shareInvitation);
-    map<json>|string? handledResponse = check handleResponse(response);
-    if (handledResponse is map<json>) {
-        return check handledResponse.cloneWithType(Permission);
-    } else {
-        return error PayloadValidationError(INVALID_RESPONSE);
-    }
-}
-
-isolated function copyDriveItem(http:Client httpClient, string url, ItemReference? parentReference, string? name) 
-                                returns @tainted string|Error {
-    json copyItemOptions = {};
-    if ((name is () || name == "") &&  parentReference is ()) {
-        copyItemOptions = {};
-    } else if (parentReference is ()) {
-        copyItemOptions = { name: name };
-    } else if (name is () || name == "") {
-        copyItemOptions = { parentReference : check parentReference.cloneWithType(json) };
-    } else {
-        copyItemOptions = {
-                            parentReference : check parentReference.cloneWithType(json),
-                            name: name
-                          };
-    }      
-    http:Response response = check httpClient->post(url, copyItemOptions);
-    map<json>|string? handledResponse = check handleCopyItemResponse(response);
-    if (handledResponse is string) {
-        return handledResponse;
-    } else {
-        return error PayloadValidationError(INVALID_RESPONSE);
-    }
-}
-
-isolated function handleCopyItemResponse(http:Response httpResponse) returns @tainted string|Error? {
-    if (httpResponse.statusCode == http:STATUS_ACCEPTED) {
-        // long running JOB
-        string locationHeader = check httpResponse.getHeader(http:LOCATION);
-        AsyncJobStatus asyncStatus = check getasyncJobStatus(<@untainted>locationHeader); 
-        return asyncStatus?.resourceId;
-    }
-    json errorPayload = check httpResponse.getJsonPayload();
-    string message = errorPayload.toString(); // Error should be defined as a user defined object
-    return error PayloadValidationError(message);
-}
-
 isolated function getasyncJobStatus(string monitorUrl) returns @tainted AsyncJobStatus|error {
     http:Client httpClient = check new(monitorUrl);
     http:Response response = check httpClient->get(EMPTY_STRING);
@@ -356,3 +130,16 @@ isolated function getasyncJobStatus(string monitorUrl) returns @tainted AsyncJob
     string message = errorPayload.toString(); // Error should be defined as a user defined object
     return error PayloadValidationError(message);
 }
+
+# Resource that provide the progress of the long running action.
+#
+# + operation - The type of long running operation
+# + percentageComplete - A value between 0 and 100 that indicates the percentage complete 
+# + resourceId - ID of the relevent DriveItem 
+# + status - String value that maps to an enumeration of possible values about the status of the job
+type AsyncJobStatus record {
+    string operation?;
+    float percentageComplete?;
+    string resourceId?;
+    AsyncJobStatusString status?;
+};

--- a/onedrive/utils.bal
+++ b/onedrive/utils.bal
@@ -100,9 +100,9 @@ isolated function validateOdataSystemQueryOption(string queryOptionName, string 
         return false;
     }
     foreach string character in queryOptionValue {
-        if (character is OpeningCharacters) {
+        if (matchOpening(character)) {
             characterArray.push(character);
-        } else if (character is ClosingCharacters) {
+        } else if (matchClosing(character)) {
             _ = characterArray.pop();
         }
     }
@@ -129,6 +129,24 @@ isolated function getasyncJobStatus(string monitorUrl) returns @tainted AsyncJob
     json errorPayload = check response.getJsonPayload();
     string message = errorPayload.toString(); // Error should be defined as a user defined object
     return error PayloadValidationError(message);
+}
+
+isolated function matchOpening(string value) returns boolean {
+    match value {
+        OPEN_BRACKET|OPEN_SQURAE_BRACKET|OPEN_CURLY_BRACKET|SINGLE_QUOTE_O|DOUBLE_QUOTE_O => {
+            return true;
+        }
+    }
+    return false;
+}
+
+isolated function matchClosing(string value) returns boolean {
+    match value {
+        CLOSE_BRACKET|CLOSE_SQURAE_BRACKET|CLOSE_CURLY_BRACKET|SINGLE_QUOTE_C|DOUBLE_QUOTE_C => {
+            return true;
+        }
+    }
+    return false;
 }
 
 # Resource that provide the progress of the long running action.


### PR DESCRIPTION
## Purpose
> Change the record types of the initially designed connector which was not well organized
- They do not distinguish clearly between the input and output record types. As a result the input parameter record types contained a large number of unnecessary fields. 
- Fix the ballerina action failing due to a code level change in the ballerina SL Beta 2 image.

## Goals
> Make the connector user friendly and reliable in UI environment
> Resolve errors in the GitHub actions

## Approach
> Redesign the record types 
> Handle the enum check using a separate function to get rid of the error

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   >  Tested all functions
 - Integration tests
   > Tested the integrated behavior of functions

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes


## Test environment
> Ubuntu 20.04
> JDK 11
> Ballerina SL Beta 1
