### PR TITLE
Fix the updated download operation with redirection handling

### DIFF
--- a/onedrive/drive.bal
+++ b/onedrive/drive.bal
@@ -68,12 +68,29 @@ isolated function updateDriveItem(http:Client httpClient, string url, DriveItem 
 
 isolated function downloadDriveItem(http:Client httpClient, string url) returns @tainted File|Error {
     http:Response response = check httpClient->get(<@untainted>url);
+    if (response.statusCode is http:REDIRECT_FOUND_302) {
+        return check handleDownloadRedirected(check response.getHeader(http:LOCATION));
+    } else {
+        json errorPayload = check response.getJsonPayload();
+        string message = errorPayload.toString(); 
+        return error PayloadValidationError(message);
+    }
+}
+
+isolated function handleDownloadRedirected(string webUrl) returns @tainted File|Error {
+    http:Client downloadClient = check new (webUrl, {
+        httpVersion: http:HTTP_1_1,
+        http1Settings: {
+            chunking: http:CHUNKING_NEVER
+        }
+    });
+    http:Response response = check downloadClient->get(EMPTY_STRING);
     if (response.statusCode is http:STATUS_OK) {
         byte[] content = check response.getBinaryPayload();
         return {
             content: content,
             mimeType: response.getContentType()
-        };  
+        }; 
     } else {
         json errorPayload = check response.getJsonPayload();
         string message = errorPayload.toString(); 

--- a/onedrive/drive.bal
+++ b/onedrive/drive.bal
@@ -68,7 +68,7 @@ isolated function updateDriveItem(http:Client httpClient, string url, DriveItem 
 
 isolated function downloadDriveItem(http:Client httpClient, string url) returns @tainted File|Error {
     http:Response response = check httpClient->get(<@untainted>url);
-    if (response.statusCode is http:REDIRECT_FOUND_302) {
+    if response.statusCode is http:REDIRECT_FOUND_302 {
         return check handleDownloadRedirected(check response.getHeader(http:LOCATION));
     } else {
         json errorPayload = check response.getJsonPayload();
@@ -77,7 +77,7 @@ isolated function downloadDriveItem(http:Client httpClient, string url) returns 
     }
 }
 
-isolated function handleDownloadRedirected(string webUrl) returns @tainted File|Error {
+isolated function handleDownloadRedirected(string webUrl) returns File|Error {
     http:Client downloadClient = check new (webUrl, {
         httpVersion: http:HTTP_1_1,
         http1Settings: {


### PR DESCRIPTION
# Description
The Download operation provides an HTTP redirection URL for the user to download the file instead of the http:OK response the API supported earlier. As our base client does not enable redirection and for handling the redirection internally, added a separate redirection logic

Fixes: https://github.com/ballerina-platform/ballerina-extended-library/issues/477

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] testDownloadConvertedFileContentById
- [x] testDownloadConvertedFileContentByPath
- [x] testDownloadFileById
- [x] testDownloadFileByPath

**Test Configuration**:
* Ballerina Version: 2201.3.0
* Operating System: Ubuntu 20.04
* Java SDK: 11

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
